### PR TITLE
feat: add functionality to generate IDs for messages

### DIFF
--- a/src/Exception/UnableToGenerateMessageId.php
+++ b/src/Exception/UnableToGenerateMessageId.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when we are unable to generate a message ID
+ */
+class UnableToGenerateMessageId extends RuntimeException implements FormatPHPException
+{
+}

--- a/src/Extractor/IdInterpolator.php
+++ b/src/Extractor/IdInterpolator.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor;
+
+use Closure;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToGenerateMessageId;
+use FormatPHP\Intl\Config;
+use FormatPHP\Intl\Descriptor;
+
+use function base64_encode;
+use function bin2hex;
+use function count;
+use function hash;
+use function hash_algos;
+use function in_array;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function sprintf;
+use function strlen;
+use function strtr;
+use function substr;
+use function trim;
+
+/**
+ * IdInterpolator supports generation of message descriptor IDs
+ *
+ * @see Config::getIdInterpolatorPattern()
+ */
+class IdInterpolator
+{
+    public const DEFAULT_ID_INTERPOLATION_PATTERN = '[sha512:contenthash:base64:6]';
+    private const PATTERN_MATCHER = '/\[(?:([^:\]]+):)?(?:hash|contenthash)(?::([a-z0-9]+))?(?::(\d+))?\]/';
+
+    /**
+     * Generates and returns an ID for the given message descriptor
+     *
+     * If the message descriptor already has an ID, we do not generate a new
+     * one; we return the current one, instead.
+     *
+     * If the message descriptor does not have a default message, we cannot
+     * generate an ID, so we throw `UnableToGenerateMessageId`.
+     *
+     * @see Config::getIdInterpolatorPattern()
+     *
+     * @throws InvalidArgument
+     * @throws UnableToGenerateMessageId
+     */
+    public function generateId(
+        Descriptor $descriptor,
+        string $idInterpolationPattern = self::DEFAULT_ID_INTERPOLATION_PATTERN
+    ): string {
+        if ($descriptor->getId() !== null) {
+            return (string) $descriptor->getId();
+        }
+
+        $contentHash = $this->buildContentHash($descriptor);
+        $options = $this->parsePattern($idInterpolationPattern);
+
+        if (!in_array($options->hashingAlgorithm, hash_algos())) {
+            throw new InvalidArgument(sprintf(
+                'Unknown or unsupported hashing algorithm: "%s".',
+                $options->hashingAlgorithm,
+            ));
+        }
+
+        $encoder = $this->getEncoder($options->encodingAlgorithm);
+        $binaryHash = hash($options->hashingAlgorithm, $contentHash, true);
+
+        return substr($encoder($binaryHash), 0, $options->length);
+    }
+
+    /**
+     * @return Closure(string):string
+     *
+     * @throws InvalidArgument
+     */
+    private function getEncoder(string $encodingType): Closure
+    {
+        switch ($encodingType) {
+            case 'base64':
+                return fn (string $data): string => base64_encode($data);
+            case 'base64url':
+                return fn (string $data): string => rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+            case 'hex':
+                return fn (string $data): string => bin2hex($data);
+        }
+
+        throw new InvalidArgument(sprintf('Unknown or unsupported encoding algorithm: "%s".', $encodingType));
+    }
+
+    /**
+     * @throws UnableToGenerateMessageId
+     */
+    private function buildContentHash(Descriptor $descriptor): string
+    {
+        $data = '';
+
+        if ($descriptor->getDefaultMessage() !== null) {
+            $data .= trim((string) preg_replace('/\n\s*/', ' ', (string) $descriptor->getDefaultMessage()));
+        }
+
+        if (strlen($data) > 0 && $descriptor->getDescription() !== null) {
+            $data .= '#' . (string) $descriptor->getDescription();
+        }
+
+        if ($data === '') {
+            throw new UnableToGenerateMessageId(
+                'To auto-generate a message ID, the message descriptor must '
+                . 'have a default message and, optionally, a description.',
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @throws InvalidArgument
+     */
+    private function parsePattern(string $pattern): IdInterpolatorOptions
+    {
+        preg_match(self::PATTERN_MATCHER, $pattern, $matches);
+
+        if (count($matches) !== 4) {
+            throw new InvalidArgument(sprintf('Pattern is not a valid ID interpolation pattern: "%s".', $pattern));
+        }
+
+        return new IdInterpolatorOptions($matches[1], $matches[2], (int) $matches[3]);
+    }
+}

--- a/src/Extractor/IdInterpolatorOptions.php
+++ b/src/Extractor/IdInterpolatorOptions.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor;
+
+use FormatPHP\Intl\Config;
+
+/**
+ * IdInterpolator options
+ *
+ * @see Config::getIdInterpolatorPattern()
+ */
+class IdInterpolatorOptions
+{
+    private const DEFAULT_HASHING_ALGORITHM = 'sha512';
+    private const DEFAULT_ENCODING_ALGORITHM = 'base64';
+    private const DEFAULT_LENGTH = 6;
+
+    public string $hashingAlgorithm;
+    public string $encodingAlgorithm;
+    public int $length;
+
+    public function __construct(
+        string $hashingAlgorithm = self::DEFAULT_HASHING_ALGORITHM,
+        string $encodingAlgorithm = self::DEFAULT_ENCODING_ALGORITHM,
+        int $length = self::DEFAULT_LENGTH
+    ) {
+        $this->hashingAlgorithm = $hashingAlgorithm;
+        $this->encodingAlgorithm = $encodingAlgorithm;
+        $this->length = $length;
+    }
+}

--- a/src/Intl/Config.php
+++ b/src/Intl/Config.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Intl;
+
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Extractor\IdInterpolatorOptions;
+
+/**
+ * FormatPHP configuration
+ */
+interface Config
+{
+    /**
+     * Returns default locale to use, if unable to support the requested locale
+     */
+    public function getDefaultLocale(): ?Locale;
+
+    /**
+     * Returns a pattern that defines how to generate missing message IDs
+     *
+     * If message descriptors are missing the id property, we will use this
+     * pattern to automatically generate IDs for them.
+     *
+     * The pattern follows this format:
+     *
+     *     [hashAlgorithm:contenthash:encodingAlgorithm:length]
+     *
+     * When passing this value, provide the hashAlgorithm, encodingAlgorithm,
+     * and length, and formatphp will calculate the contenthash.
+     *
+     * For example, if you wish to use `haval160,4` as the hashing algorithm,
+     * `hex` as the encoding algorithm, with a length of 10, you would pass
+     * the following string:
+     *
+     *     [haval160,4:contenthash:hex:10]
+     *
+     * See <https://www.php.net/hash_algos> for available hashing algorithms.
+     *
+     * The following binary-to-text encodings are supported:
+     *
+     * - `base64`
+     * - `base64url`
+     * - `hex`
+     *
+     * @see IdInterpolator
+     * @see IdInterpolatorOptions
+     */
+    public function getIdInterpolatorPattern(): string;
+
+    /**
+     * Returns locale to use for translation and localization
+     */
+    public function getLocale(): Locale;
+
+    /**
+     * Returns a collection of translation messages
+     */
+    public function getMessages(): MessageCollection;
+}

--- a/tests/Extractor/IdInterpolatorOptionsTest.php
+++ b/tests/Extractor/IdInterpolatorOptionsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Extractor;
+
+use FormatPHP\Extractor\IdInterpolatorOptions;
+use FormatPHP\Test\TestCase;
+
+class IdInterpolatorOptionsTest extends TestCase
+{
+    public function testDefaultInstantiation(): void
+    {
+        $options = new IdInterpolatorOptions();
+
+        $this->assertSame('sha512', $options->hashingAlgorithm);
+        $this->assertSame('base64', $options->encodingAlgorithm);
+        $this->assertSame(6, $options->length);
+    }
+
+    public function testConstructorArgs(): void
+    {
+        $options = new IdInterpolatorOptions('md5', 'base64url', 10);
+
+        $this->assertSame('md5', $options->hashingAlgorithm);
+        $this->assertSame('base64url', $options->encodingAlgorithm);
+        $this->assertSame(10, $options->length);
+    }
+}

--- a/tests/Extractor/IdInterpolatorTest.php
+++ b/tests/Extractor/IdInterpolatorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Extractor;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToGenerateMessageId;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Intl\Descriptor as IntlDescriptor;
+use FormatPHP\Test\TestCase;
+
+class IdInterpolatorTest extends TestCase
+{
+    /**
+     * @dataProvider generateIdProvider
+     */
+    public function testGenerateId(IntlDescriptor $descriptor, ?string $pattern, string $expectedId): void
+    {
+        $idInterpolator = new IdInterpolator();
+
+        if ($pattern !== null) {
+            $this->assertSame($expectedId, $idInterpolator->generateId($descriptor, $pattern));
+        } else {
+            $this->assertSame($expectedId, $idInterpolator->generateId($descriptor));
+        }
+    }
+
+    /**
+     * @return array<array{descriptor: IntlDescriptor, pattern: string | null, expectedId: string}>
+     */
+    public function generateIdProvider(): array
+    {
+        return [
+            'descriptor has ID' => [
+                'descriptor' => new Descriptor('aMessageId'),
+                'pattern' => null,
+                'expectedId' => 'aMessageId',
+            ],
+            'default message with default pattern' => [
+                'descriptor' => new Descriptor(null, 'my default message'),
+                'pattern' => null,
+                'expectedId' => 'LbPcjH',
+            ],
+            'default message and description with default pattern' => [
+                'descriptor' => new Descriptor(null, 'my default message', 'test description'),
+                'pattern' => null,
+                'expectedId' => 'R1aZay',
+            ],
+            'custom pattern with crc32, base64, and 8' => [
+                'descriptor' => new Descriptor(null, '<<???>>'),
+                'pattern' => '[crc32:contenthash:base64:8]',
+                'expectedId' => 'ZSFCKQ==',
+            ],
+            'custom pattern with crc32, base64url, and 8' => [
+                'descriptor' => new Descriptor(null, '<<???>>'),
+                'pattern' => '[crc32:contenthash:base64url:8]',
+                'expectedId' => 'ZSFCKQ',
+            ],
+            'custom pattern with sha3-384, base64, and 20' => [
+                'descriptor' => new Descriptor(null, '<<???/>>>>'),
+                'pattern' => '[sha3-384:contenthash:base64:20]',
+                'expectedId' => 'WC+Ex4/ILCD7Lb6tRv7x',
+            ],
+            'custom pattern with sha3-384, base64url, and 20' => [
+                'descriptor' => new Descriptor(null, '<<???/>>>>'),
+                'pattern' => '[sha3-384:contenthash:base64url:20]',
+                'expectedId' => 'WC-Ex4_ILCD7Lb6tRv7x',
+            ],
+            'custom pattern with md5, hex, and 6' => [
+                'descriptor' => new Descriptor(null, 'some message'),
+                'pattern' => '[md5:contenthash:hex:6]',
+                'expectedId' => 'df49b6',
+            ],
+            'custom pattern using hash instead of contenthash' => [
+                'descriptor' => new Descriptor(null, 'some message'),
+                'pattern' => '[md5:hash:hex:6]',
+                'expectedId' => 'df49b6',
+            ],
+        ];
+    }
+
+    public function testGenerateIdThrowsExceptionWhenUnableToGenerateMessageId(): void
+    {
+        $idInterpolator = new IdInterpolator();
+
+        $this->expectException(UnableToGenerateMessageId::class);
+        $this->expectExceptionMessage(
+            'To auto-generate a message ID, the message descriptor must '
+            . 'have a default message and, optionally, a description.',
+        );
+
+        $idInterpolator->generateId(new Descriptor(null, null, 'a description'));
+    }
+
+    public function testGenerateIdThrowsExceptionWhenInterpolationPatternIsInvalid(): void
+    {
+        $idInterpolator = new IdInterpolator();
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Pattern is not a valid ID interpolation pattern: "[sha256:something:base64:6]".',
+        );
+
+        $idInterpolator->generateId(new Descriptor(null, 'foo'), '[sha256:something:base64:6]');
+    }
+
+    public function testGenerateIdThrowsExceptionWhenHashingAlgorithmIsInvalid(): void
+    {
+        $idInterpolator = new IdInterpolator();
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Unknown or unsupported hashing algorithm: "foobar".',
+        );
+
+        $idInterpolator->generateId(new Descriptor(null, 'foo'), '[foobar:hash:base64:6]');
+    }
+
+    public function testGenerateIdThrowsExceptionWhenEncodingAlgorithmIsInvalid(): void
+    {
+        $idInterpolator = new IdInterpolator();
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Unknown or unsupported encoding algorithm: "baz".',
+        );
+
+        $idInterpolator->generateId(new Descriptor(null, 'foo'), '[md5:hash:baz:6]');
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Building on #2, the ID interpolator is an interesting creature.

This provides parity with [FormatJS functionality that automatically generates IDs for extracted messages](https://formatjs.io/docs/getting-started/message-extraction#automatic-id-generation).

The comment on `Config::getIdInterpolatorPattern()` explains the pattern.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
