### PR TITLE
feat: add formatMessage() that accepts a descriptor for a formatted message

### DIFF
--- a/src/Intl.php
+++ b/src/Intl.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP;
+
+use FormatPHP\Extractor\IdInterpolator;
+
+use function is_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * FormatPHP internationalization and localization
+ */
+class Intl implements Intl\Config, Intl\Formatters
+{
+    private Intl\Locale $locale;
+    private Intl\MessageCollection $messages;
+    private ?Intl\Locale $defaultLocale = null;
+
+    /**
+     * @param Intl\Locale | string $locale
+     * @param Intl\MessageCollection | iterable<Intl\Message> $messages
+     * @param Intl\Locale | string | null $defaultLocale
+     *
+     * @throws Exception\InvalidArgument
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function __construct($locale, iterable $messages, $defaultLocale = null)
+    {
+        $locale = is_string($locale) ? new Locale($locale) : $locale;
+        $messages = is_array($messages) ? new Intl\MessageCollection($messages) : $messages;
+        $defaultLocale = is_string($defaultLocale) ? new Locale($defaultLocale) : $defaultLocale;
+
+        if (!$locale instanceof Intl\Locale) {
+            throw new Exception\InvalidArgument(sprintf(
+                'Locale must be an instance of %s or a string locale.',
+                Intl\Locale::class,
+            ));
+        }
+
+        if (!$messages instanceof Intl\MessageCollection) {
+            throw new Exception\InvalidArgument(sprintf(
+                'Messages must be an instance of %s or an array of %s objects.',
+                Intl\MessageCollection::class,
+                Intl\Message::class,
+            ));
+        }
+
+        /** @phpstan-ignore-next-line */
+        if ($defaultLocale !== null && !($defaultLocale instanceof Intl\Locale)) {
+            throw new Exception\InvalidArgument(sprintf(
+                'Default locale must be an instance of %s, a string locale, or null.',
+                Intl\Locale::class,
+            ));
+        }
+
+        $this->locale = $locale;
+        $this->messages = $messages;
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    public function getDefaultLocale(): ?Intl\Locale
+    {
+        return $this->defaultLocale;
+    }
+
+    public function getLocale(): Intl\Locale
+    {
+        return $this->locale;
+    }
+
+    public function getMessages(): Intl\MessageCollection
+    {
+        return $this->messages;
+    }
+
+    public function getIdInterpolatorPattern(): string
+    {
+        return IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN;
+    }
+
+    /**
+     * @throws Exception\InvalidArgument
+     *
+     * @inheritdoc
+     */
+    public function formatMessage(array $descriptor, ?array $values = null): string
+    {
+        return Intl\Formatter\MessageFormatter::format($this, $descriptor, $values);
+    }
+}

--- a/src/Intl.php
+++ b/src/Intl.php
@@ -68,8 +68,14 @@ class Intl implements Intl\Config, Intl\Formatters
      *
      * @inheritdoc
      */
-    public function formatMessage(array $descriptor, ?array $values = null): string
+    public function formatMessage(array $descriptor, array $values = []): string
     {
-        return Intl\Formatter\MessageFormatter::format($this, $descriptor, $values);
+        $descriptorInstance = new Descriptor(
+            $descriptor['id'] ?? null,
+            $descriptor['defaultMessage'] ?? null,
+            $descriptor['description'] ?? null,
+        );
+
+        return Intl\Formatter\MessageFormatter::format($this, $descriptorInstance, $values);
     }
 }

--- a/src/Intl.php
+++ b/src/Intl.php
@@ -24,10 +24,6 @@ namespace FormatPHP;
 
 use FormatPHP\Extractor\IdInterpolator;
 
-use function is_array;
-use function is_string;
-use function sprintf;
-
 /**
  * FormatPHP internationalization and localization
  */
@@ -35,46 +31,13 @@ class Intl implements Intl\Config, Intl\Formatters
 {
     private Intl\Locale $locale;
     private Intl\MessageCollection $messages;
-    private ?Intl\Locale $defaultLocale = null;
+    private ?Intl\Locale $defaultLocale;
 
-    /**
-     * @param Intl\Locale | string $locale
-     * @param Intl\MessageCollection | iterable<Intl\Message> $messages
-     * @param Intl\Locale | string | null $defaultLocale
-     *
-     * @throws Exception\InvalidArgument
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     */
-    public function __construct($locale, iterable $messages, $defaultLocale = null)
-    {
-        $locale = is_string($locale) ? new Locale($locale) : $locale;
-        $messages = is_array($messages) ? new Intl\MessageCollection($messages) : $messages;
-        $defaultLocale = is_string($defaultLocale) ? new Locale($defaultLocale) : $defaultLocale;
-
-        if (!$locale instanceof Intl\Locale) {
-            throw new Exception\InvalidArgument(sprintf(
-                'Locale must be an instance of %s or a string locale.',
-                Intl\Locale::class,
-            ));
-        }
-
-        if (!$messages instanceof Intl\MessageCollection) {
-            throw new Exception\InvalidArgument(sprintf(
-                'Messages must be an instance of %s or an array of %s objects.',
-                Intl\MessageCollection::class,
-                Intl\Message::class,
-            ));
-        }
-
-        /** @phpstan-ignore-next-line */
-        if ($defaultLocale !== null && !($defaultLocale instanceof Intl\Locale)) {
-            throw new Exception\InvalidArgument(sprintf(
-                'Default locale must be an instance of %s, a string locale, or null.',
-                Intl\Locale::class,
-            ));
-        }
-
+    public function __construct(
+        Intl\Locale $locale,
+        Intl\MessageCollection $messages,
+        ?Intl\Locale $defaultLocale = null
+    ) {
         $this->locale = $locale;
         $this->messages = $messages;
         $this->defaultLocale = $defaultLocale;

--- a/src/Intl.php
+++ b/src/Intl.php
@@ -76,6 +76,8 @@ class Intl implements Intl\Config, Intl\Formatters
             $descriptor['description'] ?? null,
         );
 
-        return Intl\Formatter\MessageFormatter::format($this, $descriptorInstance, $values);
+        $formatter = new Intl\Formatter\MessageFormatter($this);
+
+        return $formatter->format($descriptorInstance, $values);
     }
 }

--- a/src/Intl/Formatter/MessageFormatter.php
+++ b/src/Intl/Formatter/MessageFormatter.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Intl\Formatter;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\MessageNotFound;
+use FormatPHP\Exception\UnableToGenerateMessageId;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Intl\Config;
+use FormatPHP\Intl\Descriptor as IntlDescriptor;
+use MessageFormatter as IntlMessageFormatter;
+
+use function is_array;
+use function is_object;
+use function preg_replace;
+use function sprintf;
+use function trim;
+
+/**
+ * Formats a message using {@link https://unicode-org.github.io/icu/userguide/format_parse/messages/ ICU Message syntax}
+ *
+ * @internal
+ */
+final class MessageFormatter
+{
+    /**
+     * Returns a translated string for the given descriptor ID
+     *
+     * If the descriptor does not have an ID, we will use a combination of the
+     * defaultMessage and description to create an ID.
+     *
+     * If we cannot find the given ID in the configured messages, we will use
+     * the descriptor's defaultMessage, if provided.
+     *
+     * @param IntlDescriptor | array{id?: string, defaultMessage?: string, description?: string} $descriptor
+     * @param object | array<array-key, int | float | string> | null $values
+     *
+     * @throws InvalidArgument
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public static function format(Config $config, $descriptor, $values = null): string
+    {
+        return (string) IntlMessageFormatter::formatMessage(
+            $config->getLocale()->getId(),
+            self::getMessage($config, $descriptor),
+            self::buildMessageValues($values),
+        );
+    }
+
+    /**
+     * @throws InvalidArgument
+     */
+    private static function buildMessageId(IntlDescriptor $descriptor, Config $config): string
+    {
+        try {
+            $messageId = (new IdInterpolator())->generateId(
+                $descriptor,
+                $config->getIdInterpolatorPattern(),
+            );
+        } catch (UnableToGenerateMessageId $exception) {
+            $messageId = '';
+        }
+
+        return $messageId;
+    }
+
+    /**
+     * @param IntlDescriptor | array{id?: string, defaultMessage?: string, description?: string} | mixed $descriptor
+     *
+     * @throws InvalidArgument
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    private static function buildDescriptor($descriptor): IntlDescriptor
+    {
+        if ($descriptor instanceof IntlDescriptor) {
+            return $descriptor;
+        }
+
+        if (is_object($descriptor)) {
+            $descriptor = (array) $descriptor;
+        }
+
+        if (!is_array($descriptor)) {
+            throw new InvalidArgument(sprintf(
+                'Descriptor must be a %s, array, or object with public properties.',
+                IntlDescriptor::class,
+            ));
+        }
+
+        return new Descriptor(
+            isset($descriptor['id']) ? (string) $descriptor['id'] : null,
+            isset($descriptor['defaultMessage']) ? (string) $descriptor['defaultMessage'] : null,
+            isset($descriptor['description']) ? (string) $descriptor['description'] : null,
+        );
+    }
+
+    /**
+     * @param object | array<array-key, int | float | string> | mixed | null $values
+     *
+     * @return mixed[]
+     *
+     * @throws InvalidArgument
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    private static function buildMessageValues($values): array
+    {
+        if (is_object($values)) {
+            $values = (array) $values;
+        }
+
+        if (!is_array($values) && $values !== null) {
+            throw new InvalidArgument(
+                'Values must be an array, an object with public properties, or null.',
+            );
+        }
+
+        return $values ?? [];
+    }
+
+    /**
+     * @param IntlDescriptor | array{id?: string, defaultMessage?: string, description?: string} $descriptor
+     *
+     * @throws InvalidArgument
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    private static function getMessage(Config $config, $descriptor): string
+    {
+        $messageDescriptor = self::buildDescriptor($descriptor);
+        $messageId = self::buildMessageId($messageDescriptor, $config);
+
+        try {
+            return self::lookupMessage($config, $messageId);
+        } catch (MessageNotFound $exception) {
+            if ($messageDescriptor->getDefaultMessage() !== null) {
+                return trim((string) preg_replace('/\n\s*/', ' ', (string) $messageDescriptor->getDefaultMessage()));
+            }
+        }
+
+        return $messageId;
+    }
+
+    /**
+     * @throws MessageNotFound
+     */
+    private static function lookupMessage(Config $config, string $messageId): string
+    {
+        try {
+            return $config->getMessages()->getMessage($messageId, $config->getLocale());
+        } catch (MessageNotFound $exception) {
+            try {
+                return $config->getMessages()->getMessage($messageId, $config->getLocale()->getFallbackLocale());
+            } catch (MessageNotFound $exception) {
+                $defaultLocale = $config->getDefaultLocale();
+                if ($defaultLocale !== null) {
+                    return $config->getMessages()->getMessage($messageId, $defaultLocale);
+                }
+            }
+        }
+
+        throw new MessageNotFound(sprintf('Unable to look up message with ID "%s".', $messageId));
+    }
+}

--- a/src/Intl/Formatters.php
+++ b/src/Intl/Formatters.php
@@ -37,7 +37,7 @@ interface Formatters
      * the descriptor's defaultMessage, if provided.
      *
      * @param array{id?: string, defaultMessage?: string, description?: string} $descriptor
-     * @param array<array-key, int | float | string> | null $values
+     * @param array<array-key, int | float | string> $values
      */
-    public function formatMessage(array $descriptor, ?array $values = null): string;
+    public function formatMessage(array $descriptor, array $values = []): string;
 }

--- a/src/Intl/Formatters.php
+++ b/src/Intl/Formatters.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Intl;
+
+/**
+ * FormatPHP formatter methods
+ */
+interface Formatters
+{
+    /**
+     * Returns a translated string for the given descriptor ID
+     *
+     * If the descriptor does not have an ID, we will use a combination of the
+     * defaultMessage and description to create an ID.
+     *
+     * If we cannot find the given ID in the configured messages, we will use
+     * the descriptor's defaultMessage, if provided.
+     *
+     * @param array{id?: string, defaultMessage?: string, description?: string} $descriptor
+     * @param array<array-key, int | float | string> | null $values
+     */
+    public function formatMessage(array $descriptor, ?array $values = null): string;
+}

--- a/tests/Intl/Formatter/MessageFormatterTest.php
+++ b/tests/Intl/Formatter/MessageFormatterTest.php
@@ -77,9 +77,11 @@ class MessageFormatterTest extends TestCase
             'getIdInterpolatorPattern' => IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN,
         ]);
 
+        $formatter = new MessageFormatter($config);
+
         $this->assertSame(
             $expected,
-            MessageFormatter::format($config, $descriptor, $replacements),
+            $formatter->format($descriptor, $replacements),
         );
     }
 

--- a/tests/Intl/Formatter/MessageFormatterTest.php
+++ b/tests/Intl/Formatter/MessageFormatterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace FormatPHP\Test\Intl\Formatter;
 
 use FormatPHP\Descriptor;
-use FormatPHP\Exception\InvalidArgument;
 use FormatPHP\Extractor\IdInterpolator;
 use FormatPHP\Intl\Config;
 use FormatPHP\Intl\Descriptor as IntlDescriptor;
@@ -17,51 +16,6 @@ use FormatPHP\Test\TestCase;
 
 class MessageFormatterTest extends TestCase
 {
-    private const MESSAGE_DESCRIPTORS = [
-        'empty' => [
-            // An empty message descriptor.
-        ],
-        'full' => [
-            'id' => 'myMessage',
-            'defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}',
-            'description' => 'This tells the user what day it is today',
-        ],
-        'id only' => [
-            'id' => 'foo',
-        ],
-        'id with defaultMessage' => [
-            'id' => 'bar',
-            'defaultMessage' => 'Howdy!',
-        ],
-        'id with description' => [
-            'id' => 'baz',
-            'description' => 'There is not default message for this one',
-        ],
-        'defaultMessage only' => [
-            'defaultMessage' => 'What are you doing this weekend?',
-        ],
-        'complicated pattern' => [
-            // There are extra newlines in here to test proper trimming.
-            'defaultMessage' => <<<'EOM'
-
-                    Last time I checked, {gender, select,
-                        male {he had}
-                        female {she had}
-                        other {they had}
-                    } {petCount, plural,
-                        =0 {no pets}
-                        =1 {a pet}
-                        other {# pets}
-                    }.
-
-                    EOM,
-            'description' => 'This is a more complicated message pattern.',
-        ],
-        'description only' => [
-            'description' => 'This description has no default message, so it shouldn\'t find a message.',
-        ],
-    ];
-
     private const TRANSLATION_MESSAGES_EN = [
         'myMessage' => 'Today is {ts, date, ::yyyyMMdd}',
         'foo' => 'A translation string with no default message',
@@ -104,60 +58,16 @@ class MessageFormatterTest extends TestCase
         $this->messageCollection = $messages;
     }
 
-    public function testFormatterThrowsExceptionForInvalidDescriptor(): void
-    {
-        $config = $this->mockery(Config::class, [
-            'getLocale->getId' => 'en',
-        ]);
-
-        $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(
-            'Descriptor must be a FormatPHP\Intl\Descriptor, array, or object with public properties.',
-        );
-
-        /**
-         * @psalm-suppress InvalidArgument
-         * @phpstan-ignore-next-line
-         */
-        MessageFormatter::format($config, 'this should cause exception');
-    }
-
-    public function testFormatterThrowsExceptionForInvalidValues(): void
-    {
-        $messages = new MessageCollection([new Message(new Locale('en'), 'foo', 'bar')]);
-
-        $config = $this->mockery(Config::class, [
-            'getLocale->getId' => 'en',
-            'getDefaultLocale' => null,
-            'getMessages' => $messages,
-            'getIdInterpolatorPattern' => IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN,
-        ]);
-
-        $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(
-            'Values must be an array, an object with public properties, or null.',
-        );
-
-        /**
-         * @psalm-suppress InvalidArgument
-         * @phpstan-ignore-next-line
-         */
-        MessageFormatter::format($config, new Descriptor('foo'), 'this should cause exception');
-    }
-
     /**
-     * @param IntlDescriptor | array{id?: string, defaultMessage?: string, description?: string} $descriptor
-     * @param object | array<array-key, int | float | string> | null $replacements
+     * @param array<array-key, int | float | string> $replacements
      *
      * @dataProvider formatProvider
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function testFormat(
         Locale $locale,
-        $descriptor,
+        IntlDescriptor $descriptor,
         string $expected,
-        $replacements = null,
+        array $replacements = [],
         ?Locale $defaultLocale = null
     ): void {
         $config = $this->mockery(Config::class, [
@@ -174,7 +84,7 @@ class MessageFormatterTest extends TestCase
     }
 
     /**
-     * @return array<array{locale: Locale, descriptor: mixed, expected: string, replacements?: mixed}>
+     * @return mixed[]
      */
     public function formatProvider(): array
     {
@@ -184,73 +94,109 @@ class MessageFormatterTest extends TestCase
         $localeFrCa = new Locale('fr-CA');
         $localeFoo = new Locale('foo');
 
+        $descriptors = [
+            'empty' => new Descriptor(),
+            'full' => new Descriptor(
+                'myMessage',
+                'Today is {ts, date, ::yyyyMMdd}',
+                'This tells the user what day it is today',
+            ),
+            'id only' => new Descriptor('foo'),
+            'id with defaultMessage' => new Descriptor('bar', 'Howdy!'),
+            'id with description' => new Descriptor('baz', null, 'There is not default message for this one'),
+            'defaultMessage only' => new Descriptor(null, 'What are you doing this weekend?'),
+            'complicated pattern' => new Descriptor(
+                null,
+                // There are extra newlines in here to test proper trimming.
+                <<<'EOM'
+
+                    Last time I checked, {gender, select,
+                        male {he had}
+                        female {she had}
+                        other {they had}
+                    } {petCount, plural,
+                        =0 {no pets}
+                        =1 {a pet}
+                        other {# pets}
+                    }.
+
+                    EOM,
+                'This is a more complicated message pattern.',
+            ),
+            'description only' => new Descriptor(
+                null,
+                null,
+                'This description has no default message, so it shouldn\'t find a message.',
+            ),
+        ];
+
         return [
             [
                 'locale' => $localeEn,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['empty'],
+                'descriptor' => $descriptors['empty'],
                 'expected' => '',
             ],
             [
                 'locale' => $localeFr,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['full'],
+                'descriptor' => $descriptors['full'],
                 'expected' => 'Nous sommes aujourd\'hui le 25/10/2021',
                 'replacements' => ['ts' => 1635204852], // Mon, 25 Oct 2021 23:34:12 +0000
             ],
             [
                 'locale' => $localeFrCa,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['id only'],
+                'descriptor' => $descriptors['id only'],
                 'expected' => 'Une chaîne de traduction sans message par défaut',
             ],
             [
                 'locale' => $localeFoo,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['id with defaultMessage'],
+                'descriptor' => $descriptors['id with defaultMessage'],
                 'expected' => 'Howdy!',
             ],
             [
                 'locale' => $localeEnGb,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['id with description'],
+                'descriptor' => $descriptors['id with description'],
                 'expected' => 'I don\'t know what to write here.',
             ],
             [
                 'locale' => $localeFr,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['defaultMessage only'],
+                'descriptor' => $descriptors['defaultMessage only'],
                 'expected' => 'Que fais-tu ce week-end?',
             ],
             [
                 'locale' => $localeEn,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'descriptor' => $descriptors['complicated pattern'],
                 'expected' => 'Last time I checked, he had no pets.',
                 'replacements' => ['gender' => 'male', 'petCount' => 0],
             ],
             [
                 'locale' => $localeFoo,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'descriptor' => $descriptors['complicated pattern'],
                 'expected' => 'Last time I checked, they had a pet.',
                 'replacements' => ['gender' => 'non-binary', 'petCount' => 1],
             ],
             [
                 'locale' => $localeFrCa,
-                'descriptor' => (object) self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'descriptor' => (object) $descriptors['complicated pattern'],
                 'expected' => 'La dernière fois que j\'ai vérifié, elle avait 2 animaux de compagnie.',
                 'replacements' => ['gender' => 'female', 'petCount' => 2],
             ],
             [
                 'locale' => $localeEn,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['description only'],
+                'descriptor' => $descriptors['description only'],
                 'expected' => '',
             ],
             [
                 'locale' => $localeFoo,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'descriptor' => $descriptors['complicated pattern'],
                 'expected' => 'La dernière fois que j\'ai vérifié, ils avaient no animaux.',
                 'replacements' => ['gender' => 'he', 'petCount' => 0],
                 'defaultLocale' => $localeFr,
             ],
             [
                 'locale' => $localeEn,
-                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'descriptor' => $descriptors['complicated pattern'],
                 'expected' => 'Last time I checked, he had a pet.',
-                'replacements' => (object) ['gender' => 'male', 'petCount' => 1],
+                'replacements' => ['gender' => 'male', 'petCount' => 1],
             ],
         ];
     }

--- a/tests/Intl/Formatter/MessageFormatterTest.php
+++ b/tests/Intl/Formatter/MessageFormatterTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Intl\Formatter;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Intl\Config;
+use FormatPHP\Intl\Descriptor as IntlDescriptor;
+use FormatPHP\Intl\Formatter\MessageFormatter;
+use FormatPHP\Intl\MessageCollection;
+use FormatPHP\Locale;
+use FormatPHP\Message;
+use FormatPHP\Test\TestCase;
+
+class MessageFormatterTest extends TestCase
+{
+    private const MESSAGE_DESCRIPTORS = [
+        'empty' => [
+            // An empty message descriptor.
+        ],
+        'full' => [
+            'id' => 'myMessage',
+            'defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}',
+            'description' => 'This tells the user what day it is today',
+        ],
+        'id only' => [
+            'id' => 'foo',
+        ],
+        'id with defaultMessage' => [
+            'id' => 'bar',
+            'defaultMessage' => 'Howdy!',
+        ],
+        'id with description' => [
+            'id' => 'baz',
+            'description' => 'There is not default message for this one',
+        ],
+        'defaultMessage only' => [
+            'defaultMessage' => 'What are you doing this weekend?',
+        ],
+        'complicated pattern' => [
+            // There are extra newlines in here to test proper trimming.
+            'defaultMessage' => <<<'EOM'
+
+                    Last time I checked, {gender, select,
+                        male {he had}
+                        female {she had}
+                        other {they had}
+                    } {petCount, plural,
+                        =0 {no pets}
+                        =1 {a pet}
+                        other {# pets}
+                    }.
+
+                    EOM,
+            'description' => 'This is a more complicated message pattern.',
+        ],
+        'description only' => [
+            'description' => 'This description has no default message, so it shouldn\'t find a message.',
+        ],
+    ];
+
+    private const TRANSLATION_MESSAGES_EN = [
+        'myMessage' => 'Today is {ts, date, ::yyyyMMdd}',
+        'foo' => 'A translation string with no default message',
+        'bar' => 'Howdy!',
+        'baz' => 'I don\'t know what to write here.',
+        'z2BIsL' => 'What are you doing this weekend?',
+        'KBErIh' => 'Last time I checked, {gender, select, male {he had} female {she had} other {they had} } '
+            . '{petCount, plural, =0 {no pets} =1 {a pet} other {# pets} }.',
+    ];
+
+    private const TRANSLATION_MESSAGES_FR = [
+        'myMessage' => 'Nous sommes aujourd\'hui le {ts, date, ::yyyyMMdd}',
+        'foo' => 'Une chaîne de traduction sans message par défaut',
+        'bar' => 'Salut!',
+        'baz' => 'Je ne sais pas quoi écrire ici.',
+        'z2BIsL' => 'Que fais-tu ce week-end?',
+        'KBErIh' => 'La dernière fois que j\'ai vérifié, {gender, select, male {il avait} female {elle avait} '
+            . 'other {ils avaient} } {petCount, plural, =0 {no animaux} =1 {un animal de compagnie} other '
+            . '{# animaux de compagnie} }.',
+    ];
+
+    private ?MessageCollection $messageCollection = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $messages = new MessageCollection();
+        $localeEn = new Locale('en');
+        $localeFr = new Locale('fr');
+
+        foreach (self::TRANSLATION_MESSAGES_EN as $id => $value) {
+            $messages[] = new Message($localeEn, $id, $value);
+        }
+
+        foreach (self::TRANSLATION_MESSAGES_FR as $id => $value) {
+            $messages[] = new Message($localeFr, $id, $value);
+        }
+
+        $this->messageCollection = $messages;
+    }
+
+    public function testFormatterThrowsExceptionForInvalidDescriptor(): void
+    {
+        $config = $this->mockery(Config::class, [
+            'getLocale->getId' => 'en',
+        ]);
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Descriptor must be a FormatPHP\Intl\Descriptor, array, or object with public properties.',
+        );
+
+        /**
+         * @psalm-suppress InvalidArgument
+         * @phpstan-ignore-next-line
+         */
+        MessageFormatter::format($config, 'this should cause exception');
+    }
+
+    public function testFormatterThrowsExceptionForInvalidValues(): void
+    {
+        $messages = new MessageCollection([new Message(new Locale('en'), 'foo', 'bar')]);
+
+        $config = $this->mockery(Config::class, [
+            'getLocale->getId' => 'en',
+            'getDefaultLocale' => null,
+            'getMessages' => $messages,
+            'getIdInterpolatorPattern' => IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN,
+        ]);
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Values must be an array, an object with public properties, or null.',
+        );
+
+        /**
+         * @psalm-suppress InvalidArgument
+         * @phpstan-ignore-next-line
+         */
+        MessageFormatter::format($config, new Descriptor('foo'), 'this should cause exception');
+    }
+
+    /**
+     * @param IntlDescriptor | array{id?: string, defaultMessage?: string, description?: string} $descriptor
+     * @param object | array<array-key, int | float | string> | null $replacements
+     *
+     * @dataProvider formatProvider
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function testFormat(
+        Locale $locale,
+        $descriptor,
+        string $expected,
+        $replacements = null,
+        ?Locale $defaultLocale = null
+    ): void {
+        $config = $this->mockery(Config::class, [
+            'getDefaultLocale' => $defaultLocale,
+            'getLocale' => $locale,
+            'getMessages' => $this->messageCollection,
+            'getIdInterpolatorPattern' => IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN,
+        ]);
+
+        $this->assertSame(
+            $expected,
+            MessageFormatter::format($config, $descriptor, $replacements),
+        );
+    }
+
+    /**
+     * @return array<array{locale: Locale, descriptor: mixed, expected: string, replacements?: mixed}>
+     */
+    public function formatProvider(): array
+    {
+        $localeEn = new Locale('en');
+        $localeEnGb = new Locale('en-GB');
+        $localeFr = new Locale('fr');
+        $localeFrCa = new Locale('fr-CA');
+        $localeFoo = new Locale('foo');
+
+        return [
+            [
+                'locale' => $localeEn,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['empty'],
+                'expected' => '',
+            ],
+            [
+                'locale' => $localeFr,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['full'],
+                'expected' => 'Nous sommes aujourd\'hui le 25/10/2021',
+                'replacements' => ['ts' => 1635204852], // Mon, 25 Oct 2021 23:34:12 +0000
+            ],
+            [
+                'locale' => $localeFrCa,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['id only'],
+                'expected' => 'Une chaîne de traduction sans message par défaut',
+            ],
+            [
+                'locale' => $localeFoo,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['id with defaultMessage'],
+                'expected' => 'Howdy!',
+            ],
+            [
+                'locale' => $localeEnGb,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['id with description'],
+                'expected' => 'I don\'t know what to write here.',
+            ],
+            [
+                'locale' => $localeFr,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['defaultMessage only'],
+                'expected' => 'Que fais-tu ce week-end?',
+            ],
+            [
+                'locale' => $localeEn,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'expected' => 'Last time I checked, he had no pets.',
+                'replacements' => ['gender' => 'male', 'petCount' => 0],
+            ],
+            [
+                'locale' => $localeFoo,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'expected' => 'Last time I checked, they had a pet.',
+                'replacements' => ['gender' => 'non-binary', 'petCount' => 1],
+            ],
+            [
+                'locale' => $localeFrCa,
+                'descriptor' => (object) self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'expected' => 'La dernière fois que j\'ai vérifié, elle avait 2 animaux de compagnie.',
+                'replacements' => ['gender' => 'female', 'petCount' => 2],
+            ],
+            [
+                'locale' => $localeEn,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['description only'],
+                'expected' => '',
+            ],
+            [
+                'locale' => $localeFoo,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'expected' => 'La dernière fois que j\'ai vérifié, ils avaient no animaux.',
+                'replacements' => ['gender' => 'he', 'petCount' => 0],
+                'defaultLocale' => $localeFr,
+            ],
+            [
+                'locale' => $localeEn,
+                'descriptor' => self::MESSAGE_DESCRIPTORS['complicated pattern'],
+                'expected' => 'Last time I checked, he had a pet.',
+                'replacements' => (object) ['gender' => 'male', 'petCount' => 1],
+            ],
+        ];
+    }
+}

--- a/tests/IntlTest.php
+++ b/tests/IntlTest.php
@@ -4,54 +4,12 @@ declare(strict_types=1);
 
 namespace FormatPHP\Test;
 
-use ArrayObject;
-use FormatPHP\Exception\InvalidArgument;
 use FormatPHP\Intl;
 use FormatPHP\Locale;
 use FormatPHP\Message;
 
 class IntlTest extends TestCase
 {
-    public function testConstructorThrowsExceptionWhenLocaleIsInvalid(): void
-    {
-        $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage('Locale must be an instance of FormatPHP\Intl\Locale or a string locale.');
-
-        /**
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        new Intl(1234, []);
-    }
-
-    public function testConstructorThrowsExceptionWhenMessagesIsInvalid(): void
-    {
-        $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(
-            'Messages must be an instance of FormatPHP\Intl\MessageCollection '
-            . 'or an array of FormatPHP\Intl\Message objects.',
-        );
-
-        /**
-         * @psalm-suppress MixedArgumentTypeCoercion
-         */
-        new Intl('en', new ArrayObject());
-    }
-
-    public function testConstructorThrowsExceptionWhenDefaultLocaleIsInvalid(): void
-    {
-        $this->expectException(InvalidArgument::class);
-        $this->expectExceptionMessage(
-            'Default locale must be an instance of FormatPHP\Intl\Locale, a string locale, or null.',
-        );
-
-        /**
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        new Intl('en', new Intl\MessageCollection(), 1234);
-    }
-
     public function testConstructorWithInstanceObjects(): void
     {
         $locale = new Locale('fr');
@@ -63,18 +21,6 @@ class IntlTest extends TestCase
         $this->assertSame($locale, $intl->getLocale());
         $this->assertSame($messageCollection, $intl->getMessages());
         $this->assertSame($defaultLocale, $intl->getDefaultLocale());
-    }
-
-    public function testConstructorWithPrimitiveTypes(): void
-    {
-        $message = new Message(new Locale('fr'), 'foo', 'un message d\'essai');
-        $intl = new Intl('fr', [$message], 'en');
-
-        $this->assertSame('fr', $intl->getLocale()->getId());
-        $this->assertCount(1, $intl->getMessages());
-        $this->assertSame($message, $intl->getMessages()[0]);
-        $this->assertNotNull($intl->getDefaultLocale());
-        $this->assertSame('en', $intl->getDefaultLocale()->getId());
     }
 
     public function testFormatMessage(): void

--- a/tests/IntlTest.php
+++ b/tests/IntlTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test;
+
+use ArrayObject;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Intl;
+use FormatPHP\Locale;
+use FormatPHP\Message;
+
+class IntlTest extends TestCase
+{
+    public function testConstructorThrowsExceptionWhenLocaleIsInvalid(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('Locale must be an instance of FormatPHP\Intl\Locale or a string locale.');
+
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         * @phpstan-ignore-next-line
+         */
+        new Intl(1234, []);
+    }
+
+    public function testConstructorThrowsExceptionWhenMessagesIsInvalid(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Messages must be an instance of FormatPHP\Intl\MessageCollection '
+            . 'or an array of FormatPHP\Intl\Message objects.',
+        );
+
+        /**
+         * @psalm-suppress MixedArgumentTypeCoercion
+         */
+        new Intl('en', new ArrayObject());
+    }
+
+    public function testConstructorThrowsExceptionWhenDefaultLocaleIsInvalid(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage(
+            'Default locale must be an instance of FormatPHP\Intl\Locale, a string locale, or null.',
+        );
+
+        /**
+         * @psalm-suppress InvalidScalarArgument
+         * @phpstan-ignore-next-line
+         */
+        new Intl('en', new Intl\MessageCollection(), 1234);
+    }
+
+    public function testConstructorWithInstanceObjects(): void
+    {
+        $locale = new Locale('fr');
+        $messageCollection = new Intl\MessageCollection();
+        $defaultLocale = new Locale('en');
+
+        $intl = new Intl($locale, $messageCollection, $defaultLocale);
+
+        $this->assertSame($locale, $intl->getLocale());
+        $this->assertSame($messageCollection, $intl->getMessages());
+        $this->assertSame($defaultLocale, $intl->getDefaultLocale());
+    }
+
+    public function testConstructorWithPrimitiveTypes(): void
+    {
+        $message = new Message(new Locale('fr'), 'foo', 'un message d\'essai');
+        $intl = new Intl('fr', [$message], 'en');
+
+        $this->assertSame('fr', $intl->getLocale()->getId());
+        $this->assertCount(1, $intl->getMessages());
+        $this->assertSame($message, $intl->getMessages()[0]);
+        $this->assertNotNull($intl->getDefaultLocale());
+        $this->assertSame('en', $intl->getDefaultLocale()->getId());
+    }
+
+    public function testFormatMessage(): void
+    {
+        $locale = new Locale('fr');
+        $message = new Message(
+            $locale,
+            'myMessage',
+            'Nous sommes aujourd\'hui le {ts, date, ::yyyyMMdd}',
+        );
+
+        $intl = new Intl($locale, new Intl\MessageCollection([$message]));
+
+        $this->assertSame(
+            'Nous sommes aujourd\'hui le 25/10/2021',
+            $intl->formatMessage(
+                [
+                    'id' => 'myMessage',
+                    'defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}',
+                ],
+                [
+                    'ts' => 1635204852, // Mon, 25 Oct 2021 23:34:12 +0000
+                ],
+            ),
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Again, this builds on #3 and provides the bulk of the "formatting" functionality. In general, when wanting to format a message, you'll do something like this:

```php
$messages = somethingThatLoadsMessages();

$intl = new \FormatPHP\Intl('en-US', $messages);

$intl->formatMessage(
    [
        'id' => 'my.message',
        'defaultMessage' => <<<EOM
            You have {numPhotos, plural,
                =0 {no photos.}
                =1 {one photo.}
                other {# photos.}
            }
            EOM,
    ],
    [
        'numPhotos' => getPhotosCount(),
    ]
);
```

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
