### PR TITLE
feat: provide tools for working with files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ramsey/collection": "^1.2",
+        "webmozart/glob": "^4.4",
         "yiisoft/i18n": "^1.0"
     },
     "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,8 @@
     <file>./src</file>
     <file>./tests</file>
 
+    <exclude-pattern>*/tests/*/fixtures/*</exclude-pattern>
+
     <rule ref="Ramsey"/>
 
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,5 @@ parameters:
     paths:
         - ./src
         - ./tests
+    excludePaths:
+        - */tests/*/fixtures/*

--- a/src/Exception/ImproperContext.php
+++ b/src/Exception/ImproperContext.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Exception;
+
+use LogicException;
+
+/**
+ * Thrown when a method is called in the wrong context
+ *
+ * For example, if a method is called while the script is running in a Web SAPI
+ * context when the method should only be called in a CLI SAPI context.
+ */
+class ImproperContext extends LogicException implements FormatPHPException
+{
+}

--- a/src/Exception/UnableToProcessFile.php
+++ b/src/Exception/UnableToProcessFile.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when we are unable to process a file for message extraction
+ */
+class UnableToProcessFile extends RuntimeException implements FormatPHPException
+{
+}

--- a/src/Exception/UnableToWriteFile.php
+++ b/src/Exception/UnableToWriteFile.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when we are unable to write to a file
+ */
+class UnableToWriteFile extends RuntimeException implements FormatPHPException
+{
+}

--- a/src/Util/File.php
+++ b/src/Util/File.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Util;
+
+use Closure;
+use FormatPHP\Exception\ImproperContext;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Exception\UnableToWriteFile;
+
+use function file_get_contents;
+use function file_put_contents;
+use function fwrite;
+use function get_resource_type;
+use function getcwd;
+use function gettype;
+use function is_callable;
+use function is_dir;
+use function is_readable;
+use function is_resource;
+use function is_string;
+use function sprintf;
+use function strlen;
+
+use const PHP_SAPI;
+
+/**
+ * File and path utilities
+ *
+ * @internal
+ */
+class File
+{
+    private static ?string $currentWorkingDir = null;
+
+    /**
+     * Returns the contents of a file
+     *
+     * @throws UnableToProcessFile
+     */
+    public function getContents(string $filePath): string
+    {
+        if (!$this->isReadable($filePath)) {
+            throw new UnableToProcessFile(sprintf(
+                'File does not exist or you do not have permission to read it: "%s".',
+                $filePath,
+            ));
+        }
+
+        if ($this->isDirectory($filePath)) {
+            throw new UnableToProcessFile(sprintf('File path is a directory: "%s".', $filePath));
+        }
+
+        $contents = @file_get_contents($filePath) ?: null;
+
+        if ($contents === null) {
+            throw new UnableToProcessFile(sprintf('Could not open file for reading: "%s".', $filePath));
+        }
+
+        return $contents;
+    }
+
+    /**
+     * @param string | resource | mixed $file
+     */
+    public function writeContents($file, string $contents): void
+    {
+        if (!is_string($file) && (!is_resource($file) || get_resource_type($file) !== 'stream')) {
+            throw new InvalidArgument(sprintf(
+                'File must be a string path or a stream resource; received %s.',
+                gettype($file),
+            ));
+        }
+
+        if (is_resource($file)) {
+            $bytes = @fwrite($file, $contents);
+
+            if ($bytes === false) {
+                throw new UnableToWriteFile('Unable to write contents to stream resource.');
+            }
+
+            return;
+        }
+
+        $bytes = @file_put_contents($file, $contents);
+
+        if ($bytes === false) {
+            throw new UnableToWriteFile(sprintf('Unable to write contents to file "%s".', $file));
+        }
+    }
+
+    /**
+     * Returns `true` if the path is a directory
+     */
+    public function isDirectory(string $path): bool
+    {
+        return @is_dir($path);
+    }
+
+    /**
+     * Returns `true` if the path is readable
+     */
+    public function isReadable(string $path): bool
+    {
+        return @is_readable($path);
+    }
+
+    /**
+     * Returns the current working directory
+     *
+     * This is not necessarily the directory from which the script is running,
+     * nor is it the location of this class file. It is the directory in which
+     * the process is currently working, which can change if using
+     * {@link https://www.php.net/chdir chdir()} or `cd` to change the working
+     * directory.
+     */
+    public function getCurrentWorkingDirectory(): string
+    {
+        if (self::$currentWorkingDir === null) {
+            self::$currentWorkingDir = getcwd() ?: '';
+        }
+
+        return strlen(self::$currentWorkingDir) > 0 ? self::$currentWorkingDir . '/' : '';
+    }
+
+    /**
+     * Loads a PHP script and returns its Closure
+     *
+     * PHP needs a taint mode, so we can determine whether $path might have
+     * come from external sources. If it did, we don't want to attempt to
+     * include it here. As a result, we only allow calling this method from a
+     * CLI SAPI context. Calling from a Web SAPI context is forbidden.
+     *
+     * @throws ImproperContext
+     * @throws InvalidArgument
+     */
+    public function loadClosureFromScript(string $path): ?Closure
+    {
+        if ($this->getSapiName() !== 'cli') {
+            throw new ImproperContext(sprintf(
+                'Method must be called from CLI SAPI context only; called from %s context.',
+                $this->getSapiName(),
+            ));
+        }
+
+        if (!$this->isReadable($path) || $this->isDirectory($path)) {
+            return null;
+        }
+
+        /**
+         * @var Closure | callable | int $closure
+         * @psalm-suppress UnresolvableInclude
+         */
+        $closure = @include $path;
+
+        if (!$closure instanceof Closure && is_callable($closure)) {
+            $closure = Closure::fromCallable($closure);
+        }
+
+        if ($closure instanceof Closure) {
+            return $closure;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the name of the current SAPI in which PHP is running
+     *
+     * This method exists for ease of mocking this value from tests.
+     */
+    protected function getSapiName(): string
+    {
+        return PHP_SAPI;
+    }
+}

--- a/src/Util/Globber.php
+++ b/src/Util/Globber.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Util;
+
+use Webmozart\Glob\Glob;
+
+use function array_filter;
+use function array_merge;
+use function array_values;
+use function strpos;
+
+/**
+ * Find files using glob patterns
+ *
+ * @internal
+ */
+class Globber
+{
+    private File $fileUtility;
+
+    public function __construct(File $fileUtility)
+    {
+        $this->fileUtility = $fileUtility;
+    }
+
+    /**
+     * Returns an array of files matching the provided glob patterns, optionally
+     * filtered by the "ignore" glob patterns
+     *
+     * @param string[] $globs
+     * @param string[] $ignoreGlobs
+     *
+     * @return string[]
+     */
+    public function find(array $globs, array $ignoreGlobs): array
+    {
+        $filePaths = [];
+
+        foreach ($globs as $glob) {
+            $filePaths = array_merge($filePaths, $this->glob($this->formatGlob($glob)));
+        }
+
+        if ($ignoreGlobs !== []) {
+            $filePaths = $this->filterIgnores($filePaths, $ignoreGlobs);
+        }
+
+        return array_values(array_filter(
+            $filePaths,
+            fn (string $path): bool => !$this->fileUtility->isDirectory($path),
+        ));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function glob(string $glob): array
+    {
+        return Glob::glob($glob);
+    }
+
+    /**
+     * @param string[] $filePaths
+     * @param string[] $ignores
+     *
+     * @return string[]
+     */
+    private function filterIgnores(array $filePaths, array $ignores): array
+    {
+        $filteredPaths = [];
+
+        foreach ($filePaths as $path) {
+            foreach ($ignores as $ignore) {
+                if (Glob::match($path, $this->formatGlob($ignore))) {
+                    continue 2;
+                }
+            }
+
+            $filteredPaths[] = $path;
+        }
+
+        return $filteredPaths;
+    }
+
+    private function formatGlob(string $glob): string
+    {
+        // If the path doesn't start from the root, prepend the current
+        // working directory to it.
+        if (strpos($glob, '/') !== 0) {
+            $glob = $this->fileUtility->getCurrentWorkingDirectory() . $glob;
+        }
+
+        // If the path is a directory, append `/**/*` to recursively
+        // search the directory.
+        if ($this->fileUtility->isDirectory($glob)) {
+            $glob .= '/**/*';
+        }
+
+        return $glob;
+    }
+}

--- a/tests/Util/FileTest.php
+++ b/tests/Util/FileTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Util;
+
+use Closure;
+use FormatPHP\Exception\ImproperContext;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Exception\UnableToWriteFile;
+use FormatPHP\Test\TestCase;
+use FormatPHP\Util\File;
+
+use function assert;
+use function file_get_contents;
+use function fopen;
+use function fread;
+use function fseek;
+use function getcwd;
+use function is_resource;
+use function is_writable;
+use function sprintf;
+use function sys_get_temp_dir;
+use function tempnam;
+use function tmpfile;
+use function unlink;
+
+class FileTest extends TestCase
+{
+    public function testGetContentsReturnsFileContents(): void
+    {
+        $file = new File();
+        $contents = $file->getContents(__FILE__);
+
+        $this->assertStringContainsString('FileTest', $contents);
+    }
+
+    public function testGetContentsThrowsExceptionForUnreadableFile(): void
+    {
+        $file = new File();
+
+        $this->expectException(UnableToProcessFile::class);
+        $this->expectExceptionMessage('File does not exist or you do not have permission to read it: "foo-bar.txt".');
+
+        $file->getContents('foo-bar.txt');
+    }
+
+    public function testGetContentsThrowsExceptionForDirectory(): void
+    {
+        $file = new File();
+
+        $this->expectException(UnableToProcessFile::class);
+        $this->expectExceptionMessage(sprintf('File path is a directory: "%s".', __DIR__));
+
+        $file->getContents(__DIR__);
+    }
+
+    public function testGetContentsThrowsExceptionWhenReadingOtherwiseFails(): void
+    {
+        $file = $this->mockery(File::class, [
+            'isReadable' => true,
+            'isDirectory' => false,
+        ]);
+        $file->shouldReceive('getContents')->passthru();
+
+        $this->expectException(UnableToProcessFile::class);
+        $this->expectExceptionMessage('Could not open file for reading: "whatever.txt".');
+
+        $file->getContents('whatever.txt');
+    }
+
+    public function testIsDirectory(): void
+    {
+        $file = new File();
+
+        $this->assertTrue($file->isDirectory(__DIR__));
+    }
+
+    public function testIsReadable(): void
+    {
+        $file = new File();
+
+        $this->assertTrue($file->isReadable(__FILE__));
+    }
+
+    public function testGetCurrentWorkingDirectory(): void
+    {
+        $file = new File();
+        $cwd = $file->getCurrentWorkingDirectory();
+
+        $this->assertSame(getcwd() . '/', $cwd);
+
+        // Try it again for coverage skipping the `if` statement.
+        $this->assertSame($cwd, $file->getCurrentWorkingDirectory());
+    }
+
+    public function testLoadClosureFromScriptThrowsExceptionWhenNotUsingCliSapi(): void
+    {
+        $file = $this->mockery(File::class);
+        $file->shouldAllowMockingProtectedMethods();
+        $file->shouldReceive('getSapiName')->andReturn('not-cli');
+        $file->shouldReceive('loadClosureFromScript')->passthru();
+
+        $this->expectException(ImproperContext::class);
+        $this->expectExceptionMessage(
+            'Method must be called from CLI SAPI context only; called from not-cli context.',
+        );
+
+        $file->loadClosureFromScript('/path/to/script.php');
+    }
+
+    public function testLoadClosureFromScriptThrowsExceptionWhenPathIsNotReadable(): void
+    {
+        $file = $this->mockery(File::class);
+        $file->shouldAllowMockingProtectedMethods();
+        $file->shouldReceive('getSapiName')->andReturn('cli');
+        $file->shouldReceive('loadClosureFromScript')->passthru();
+        $file->expects()->isReadable('/path/to/script.php')->andReturnFalse();
+
+        $this->assertNull($file->loadClosureFromScript('/path/to/script.php'));
+    }
+
+    public function testLoadClosureFromScriptThrowsExceptionWhenPathIsADirectory(): void
+    {
+        $file = $this->mockery(File::class);
+        $file->shouldAllowMockingProtectedMethods();
+        $file->shouldReceive('getSapiName')->andReturn('cli');
+        $file->shouldReceive('loadClosureFromScript')->passthru();
+        $file->expects()->isReadable('/path/to/script.php')->andReturnTrue();
+        $file->expects()->isDirectory('/path/to/script.php')->andReturnTrue();
+
+        $this->assertNull($file->loadClosureFromScript('/path/to/script.php'));
+    }
+
+    /**
+     * @dataProvider loadClosureFromScriptProvider
+     */
+    public function testLoadClosureFromScript(string $path, bool $expectClosure): void
+    {
+        $file = new File();
+        $closure = $file->loadClosureFromScript($path);
+
+        if ($expectClosure === true) {
+            $this->assertInstanceOf(Closure::class, $closure);
+        } else {
+            $this->assertNull($closure);
+        }
+    }
+
+    /**
+     * @return array<array{path: string, expectClosure: bool}>
+     */
+    public function loadClosureFromScriptProvider(): array
+    {
+        return [
+            [
+                'path' => __DIR__ . '/fixtures/load-closure-01.php',
+                'expectClosure' => true,
+            ],
+            [
+                'path' => __DIR__ . '/fixtures/load-closure-02.php',
+                'expectClosure' => true,
+            ],
+            [
+                'path' => __DIR__ . '/fixtures/load-closure-03.php',
+                'expectClosure' => true,
+            ],
+            [
+                'path' => __DIR__ . '/fixtures/load-closure-04.php',
+                'expectClosure' => false,
+            ],
+            [
+                'path' => __DIR__ . '/fixtures/load-closure-05.php',
+                'expectClosure' => false,
+            ],
+        ];
+    }
+
+    public function testWriteContentsThrowsExceptionWhenFileIsNotAString(): void
+    {
+        $file = new File();
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('File must be a string path or a stream resource; received array.');
+
+        $file->writeContents([], 'string to write');
+    }
+
+    public function testWriteContentsThrowsExceptionWhenUnableToWriteToResource(): void
+    {
+        // Open this test file for reading only.
+        $resource = fopen(__FILE__, 'r');
+        assert(is_resource($resource));
+
+        $file = new File();
+
+        $this->expectException(UnableToWriteFile::class);
+        $this->expectExceptionMessage('Unable to write contents to stream resource.');
+
+        $file->writeContents($resource, 'string to write');
+    }
+
+    public function testWriteContentsToResource(): void
+    {
+        $tmpFile = tmpfile();
+        assert(is_resource($tmpFile));
+
+        $file = new File();
+        $file->writeContents($tmpFile, 'string to write');
+
+        fseek($tmpFile, 0);
+
+        $this->assertStringContainsString('string to write', (string) fread($tmpFile, 1024));
+    }
+
+    public function testWriteContentsThrowsExceptionWhenUnableToWriteToFile(): void
+    {
+        $file = new File();
+
+        $this->expectException(UnableToWriteFile::class);
+        $this->expectExceptionMessage('Unable to write contents to file "/path/to/fake/file".');
+
+        $file->writeContents('/path/to/fake/file', 'string to write');
+    }
+
+    public function testWriteContentsToFile(): void
+    {
+        $tmpFile = (string) tempnam(sys_get_temp_dir(), 'formatphp-');
+        assert(is_writable($tmpFile));
+
+        $file = new File();
+        $file->writeContents($tmpFile, 'string to write');
+
+        $this->assertStringContainsString('string to write', (string) file_get_contents($tmpFile));
+
+        unlink($tmpFile);
+    }
+}

--- a/tests/Util/GlobberTest.php
+++ b/tests/Util/GlobberTest.php
@@ -82,16 +82,12 @@ class GlobberTest extends TestCase
             ->with('/path/to/other/folder/**/*')
             ->andReturn($pathsFound['/path/to/other/folder']);
 
-        $this->assertSame(
-            $expected,
-            $globber->find(
-                array_keys($pathsFound),
-                [
-                    '/path/to/other/folder/foo',
-                    'baz/**/*.json',
-                ],
-            ),
-        );
+        $returnedPaths = [];
+        foreach ($globber->find(array_keys($pathsFound), ['/path/to/other/folder/foo', 'baz/**/*.json']) as $result) {
+            $returnedPaths[] = $result;
+        }
+
+        $this->assertEquals($expected, $returnedPaths);
     }
 
     public function testGlob(): void

--- a/tests/Util/GlobberTest.php
+++ b/tests/Util/GlobberTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Util;
+
+use FormatPHP\Test\TestCase;
+use FormatPHP\Util\File;
+use FormatPHP\Util\Globber;
+
+use function array_keys;
+
+class GlobberTest extends TestCase
+{
+    public function testFind(): void
+    {
+        $expected = [
+            '/path/to/folder/aaa.json',
+            '/path/to/folder/foo/bbb.json',
+            '/path/to/folder/foo/bar/some.php',
+            '/path/to/folder/baz/other.php',
+            '/path/to/other/folder/baz/ccc.txt',
+        ];
+
+        $pathsFound = [
+            '**/*.json' => [
+                '/path/to/folder/aaa.json',
+                '/path/to/folder/foo',
+                '/path/to/folder/foo/bbb.json',
+                '/path/to/folder/baz',
+                '/path/to/folder/baz/qux/ccc.json',
+            ],
+            '**/*.php' => [
+                '/path/to/folder/foo/bar/some.php',
+                '/path/to/folder/baz/other.php',
+            ],
+            '/path/to/other/folder' => [
+                '/path/to/other/folder',
+                '/path/to/other/folder/foo',
+                '/path/to/other/folder/foo/aaa.txt',
+                '/path/to/other/folder/foo/bar/bbb.txt',
+                '/path/to/other/folder/baz',
+                '/path/to/other/folder/baz/ccc.txt',
+            ],
+        ];
+
+        $file = $this->mockery(File::class);
+
+        $file->shouldReceive('getCurrentWorkingDirectory')->andReturn('/path/to/folder/');
+        $file->shouldReceive('isDirectory')->with('/path/to/folder/**/*.json')->andReturnFalse();
+        $file->shouldReceive('isDirectory')->with('/path/to/folder/**/*.php')->andReturnFalse();
+        $file->shouldReceive('isDirectory')->with('/path/to/folder/baz/**/*.json')->andReturnFalse();
+
+        $file->shouldReceive('isDirectory')->with('/path/to/folder/foo')->andReturnTrue();
+        $file->shouldReceive('isDirectory')->with('/path/to/folder/baz')->andReturnTrue();
+        $file->shouldReceive('isDirectory')->with('/path/to/other/folder')->andReturnTrue();
+        $file->shouldReceive('isDirectory')->with('/path/to/other/folder/foo')->andReturnTrue();
+        $file->shouldReceive('isDirectory')->with('/path/to/other/folder/baz')->andReturnTrue();
+
+        foreach ($expected as $path) {
+            $file->shouldReceive('isDirectory')->with($path)->andReturnFalse();
+        }
+
+        $globber = $this->mockery(Globber::class, [$file]);
+        $globber->shouldReceive('find')->passthru();
+
+        $globber
+            ->shouldReceive('glob')
+            ->once()
+            ->with('/path/to/folder/**/*.json')
+            ->andReturn($pathsFound['**/*.json']);
+
+        $globber
+            ->shouldReceive('glob')
+            ->once()
+            ->with('/path/to/folder/**/*.php')
+            ->andReturn($pathsFound['**/*.php']);
+
+        $globber
+            ->shouldReceive('glob')
+            ->once()
+            ->with('/path/to/other/folder/**/*')
+            ->andReturn($pathsFound['/path/to/other/folder']);
+
+        $this->assertSame(
+            $expected,
+            $globber->find(
+                array_keys($pathsFound),
+                [
+                    '/path/to/other/folder/foo',
+                    'baz/**/*.json',
+                ],
+            ),
+        );
+    }
+
+    public function testGlob(): void
+    {
+        $globber = new Globber($this->mockery(File::class));
+
+        $this->assertContainsOnly('string', $globber->glob(__DIR__ . '/**/*Test.php'));
+    }
+}

--- a/tests/Util/fixtures/load-closure-01.php
+++ b/tests/Util/fixtures/load-closure-01.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return new class {
+    public function __invoke(): void
+    {
+    }
+};

--- a/tests/Util/fixtures/load-closure-02.php
+++ b/tests/Util/fixtures/load-closure-02.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+return function (): void {
+};

--- a/tests/Util/fixtures/load-closure-03.php
+++ b/tests/Util/fixtures/load-closure-03.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = new class {
+    public function doSomething(): void
+    {
+    }
+};
+
+return [$foo, 'doSomething'];

--- a/tests/Util/fixtures/load-closure-04.php
+++ b/tests/Util/fixtures/load-closure-04.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return ['not', 'a', 'callable'];

--- a/tests/Util/fixtures/load-closure-05.php
+++ b/tests/Util/fixtures/load-closure-05.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+ob_start();
+
+$foo = "This script doesn't return anything.";
+echo $foo;
+
+ob_end_clean();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR provides some tools for working with files and file globbing. The file globbing comes into play in a later PR, when passing files on the command line, like this:

```shell
formatphp extract 'src/**/*.php'
```

PHP's built-in `glob()` function wraps `glob()` from libc, which doesn't support the [globstar](https://www.linuxjournal.com/content/globstar-new-bash-globbing-option) most folks are familiar with these days.

The other functionality provided here is mainly for easier testing and mocking of other classes (in subsequent PRs).

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
