### PR TITLE
feat: parse descriptors from PHP source files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": "^7.4 || ^8",
         "ext-intl": "*",
         "ext-json": "*",
+        "nikic/php-parser": "^4.13",
         "ramsey/collection": "^1.2",
         "webmozart/glob": "^4.4",
         "yiisoft/i18n": "^1.0"

--- a/src/Exception/UnableToParseDescriptor.php
+++ b/src/Exception/UnableToParseDescriptor.php
@@ -20,23 +20,13 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Extractor\Parser;
+namespace FormatPHP\Exception;
 
-use FormatPHP\Exception\UnableToProcessFile;
-use FormatPHP\Intl\DescriptorCollection;
+use RuntimeException;
 
 /**
- * Parses message descriptors from application source code files
+ * Thrown when we are unable to parse a descriptor from source code
  */
-interface DescriptorParser
+class UnableToParseDescriptor extends RuntimeException implements FormatPHPException
 {
-    /**
-     * @throws UnableToProcessFile
-     */
-    public function parse(string $filePath): DescriptorCollection;
-
-    /**
-     * @return Error[]
-     */
-    public function getErrors(): array;
 }

--- a/src/Exception/UnableToParsePragma.php
+++ b/src/Exception/UnableToParsePragma.php
@@ -20,23 +20,13 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Extractor\Parser;
+namespace FormatPHP\Exception;
 
-use FormatPHP\Exception\UnableToProcessFile;
-use FormatPHP\Intl\DescriptorCollection;
+use RuntimeException;
 
 /**
- * Parses message descriptors from application source code files
+ * Thrown when we are unable to parse pragma metadata from source code
  */
-interface DescriptorParser
+class UnableToParsePragma extends RuntimeException implements FormatPHPException
 {
-    /**
-     * @throws UnableToProcessFile
-     */
-    public function parse(string $filePath): DescriptorCollection;
-
-    /**
-     * @return Error[]
-     */
-    public function getErrors(): array;
 }

--- a/src/Extractor/Parser/Descriptor/DescriptorCollectorVisitor.php
+++ b/src/Extractor/Parser/Descriptor/DescriptorCollectorVisitor.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor\Parser\Descriptor;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToGenerateMessageId;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Intl\Descriptor as IntlDescriptor;
+use FormatPHP\Intl\DescriptorCollection;
+use PhpParser\Node;
+use PhpParser\NodeAbstract;
+use PhpParser\NodeVisitorAbstract;
+
+use function assert;
+use function in_array;
+use function preg_replace;
+use function trim;
+
+/**
+ * A PhpParser\NodeVisitor that collects message descriptors from parsed source code
+ */
+class DescriptorCollectorVisitor extends NodeVisitorAbstract
+{
+    private DescriptorCollection $descriptors;
+    private string $filePath;
+    private bool $preserveWhitespace;
+    private IdInterpolator $idInterpolator;
+    private string $idInterpolatorPattern;
+
+    /**
+     * @var string[]
+     */
+    private array $functionNames;
+
+    /**
+     * @param string[] $functionNames Function names from which to parse
+     *     descriptors from source code
+     */
+    public function __construct(
+        string $filePath,
+        array $functionNames = [],
+        bool $preserveWhitespace = false,
+        string $idInterpolatorPattern = IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN
+    ) {
+        $this->filePath = $filePath;
+        $this->functionNames = $functionNames;
+        $this->preserveWhitespace = $preserveWhitespace;
+        $this->descriptors = new DescriptorCollection();
+        $this->idInterpolator = new IdInterpolator();
+        $this->idInterpolatorPattern = $idInterpolatorPattern;
+    }
+
+    public function getDescriptors(): DescriptorCollection
+    {
+        return $this->descriptors;
+    }
+
+    /**
+     * @return int | Node | null
+     *
+     * @throws InvalidArgument
+     * @throws UnableToGenerateMessageId
+     */
+    public function enterNode(Node $node)
+    {
+        if (!$node instanceof Node\Expr\MethodCall && !$node instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        if (!$node->name instanceof Node\Identifier && !$node->name instanceof Node\Name) {
+            return null;
+        }
+
+        $functionName = $this->parseFunctionName($node->name);
+
+        if ($this->isFunctionForParsing($functionName)) {
+            $descriptor = $node->getArgs()[0] ?? null;
+
+            if ($descriptor === null) {
+                return null;
+            }
+
+            if (!$descriptor->value instanceof Node\Expr\Array_) {
+                return null;
+            }
+
+            $parsedDescriptor = $this->parseDescriptor($descriptor);
+            if ($parsedDescriptor !== null) {
+                $this->descriptors[] = $this->ensureId($parsedDescriptor);
+            }
+        }
+
+        return null;
+    }
+
+    private function parseDescriptor(Node\Arg $descriptorArgument): ?IntlDescriptor
+    {
+        /** @var array{id?: string, defaultMessage?: string, description?: string} $properties */
+        $properties = [];
+
+        assert($descriptorArgument->value instanceof Node\Expr\Array_);
+
+        foreach ($descriptorArgument->value->items as $item) {
+            if (!$this->isValidDescriptorItem($item)) {
+                continue;
+            }
+
+            assert($item !== null);
+            assert($item->key instanceof Node\Scalar\String_);
+            assert($item->value instanceof Node\Scalar\String_);
+
+            $properties[$item->key->value] = $item->value->value;
+        }
+
+        if (!isset($properties['id']) && !isset($properties['defaultMessage']) && !isset($properties['description'])) {
+            return null;
+        }
+
+        return new Descriptor(
+            $properties['id'] ?? null,
+            $this->clean($properties['defaultMessage'] ?? null) ?? $properties['id'] ?? null,
+            $this->clean($properties['description'] ?? null) ?? null,
+            $this->filePath,
+            $descriptorArgument->getStartFilePos(),
+            $descriptorArgument->getEndFilePos(),
+            $descriptorArgument->getLine(),
+        );
+    }
+
+    /**
+     * @param Node\Identifier | Node\Name $node
+     */
+    private function parseFunctionName(NodeAbstract $node): string
+    {
+        if ($node instanceof Node\Identifier) {
+            return $node->name;
+        }
+
+        return $node->getLast();
+    }
+
+    private function isFunctionForParsing(string $name): bool
+    {
+        return in_array($name, $this->functionNames);
+    }
+
+    private function isValidDescriptorItem(?Node\Expr\ArrayItem $item): bool
+    {
+        return $item !== null
+            && $item->key instanceof Node\Scalar\String_
+            && $item->value instanceof Node\Scalar\String_;
+    }
+
+    private function clean(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($this->preserveWhitespace === true) {
+            return $value;
+        }
+
+        return trim((string) preg_replace('/\s+/m', ' ', $value));
+    }
+
+    /**
+     * @throws InvalidArgument
+     * @throws UnableToGenerateMessageId
+     */
+    private function ensureId(IntlDescriptor $descriptor): IntlDescriptor
+    {
+        $descriptor->setId($this->idInterpolator->generateId($descriptor, $this->idInterpolatorPattern));
+
+        return $descriptor;
+    }
+}

--- a/src/Extractor/Parser/Descriptor/PhpParser.php
+++ b/src/Extractor/Parser/Descriptor/PhpParser.php
@@ -156,9 +156,11 @@ class PhpParser implements DescriptorParser
             return $descriptors;
         }
 
+        $metadata = $pragmaCollector->getMetadata();
+
         foreach ($descriptors as $descriptor) {
             if ($descriptor instanceof ExtendedDescriptor) {
-                $descriptor->setMetadata($pragmaCollector->getMetadata());
+                $descriptor->setMetadata($metadata);
             }
         }
 

--- a/src/Extractor/Parser/Descriptor/PhpParser.php
+++ b/src/Extractor/Parser/Descriptor/PhpParser.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor\Parser\Descriptor;
+
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Extractor\Parser\DescriptorParser;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Intl\ExtendedDescriptor;
+use FormatPHP\Util\File;
+use LogicException;
+use PhpParser\Lexer;
+use PhpParser\Lexer\Emulative;
+use PhpParser\NodeTraverser;
+use PhpParser\Parser;
+use PhpParser\Parser\Php7 as Php7Parser;
+
+use function assert;
+use function count;
+use function in_array;
+use function pathinfo;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Parses message descriptors from application PHP source code files
+ */
+class PhpParser implements DescriptorParser
+{
+    private const PHP_PATH_EXTENSIONS = ['php', 'phtml'];
+
+    private File $file;
+    private Lexer $lexer;
+    private Parser $parser;
+    private ?string $pragma;
+    private bool $preserveWhitespace;
+    private string $idInterpolatorPattern;
+
+    /**
+     * @var string[]
+     */
+    private array $functionNames;
+
+    /**
+     * @param string[] $functionNames Function names from which to parse
+     *     descriptors from source code
+     *
+     * @throws LogicException
+     */
+    public function __construct(
+        File $file,
+        array $functionNames = [],
+        ?string $pragma = null,
+        bool $preserveWhitespace = false,
+        string $idInterpolatorPattern = IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN
+    ) {
+        $this->file = $file;
+        $this->functionNames = $functionNames;
+        $this->pragma = $pragma;
+        $this->preserveWhitespace = $preserveWhitespace;
+        $this->idInterpolatorPattern = $idInterpolatorPattern;
+
+        $this->lexer = new Emulative([
+            'usedAttributes' => [
+                'comments',
+                'endFilePos',
+                'endLine',
+                'endTokenPos',
+                'startFilePos',
+                'startLine',
+                'startTokenPos',
+            ],
+        ]);
+
+        $this->parser = new Php7Parser($this->lexer);
+    }
+
+    /**
+     * @throws UnableToProcessFile
+     */
+    public function parse(string $filePath): DescriptorCollection
+    {
+        if (!$this->isPhpFile($filePath)) {
+            return new DescriptorCollection();
+        }
+
+        $statements = $this->parser->parse($this->file->getContents($filePath));
+        assert($statements !== null);
+
+        $descriptorCollector = new DescriptorCollectorVisitor(
+            $filePath,
+            $this->functionNames,
+            $this->preserveWhitespace,
+            $this->idInterpolatorPattern,
+        );
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($descriptorCollector);
+
+        $pragmaCollector = null;
+        if ($this->pragma !== null) {
+            $pragmaCollector = new PragmaCollectorVisitor($this->pragma);
+            $traverser->addVisitor($pragmaCollector);
+        }
+
+        $traverser->traverse($statements);
+
+        return $this->applyMetadata($descriptorCollector->getDescriptors(), $pragmaCollector);
+    }
+
+    private function applyMetadata(
+        DescriptorCollection $descriptors,
+        ?PragmaCollectorVisitor $pragmaCollector
+    ): DescriptorCollection {
+        if ($pragmaCollector === null || count($pragmaCollector->getMetadata()) === 0) {
+            return $descriptors;
+        }
+
+        foreach ($descriptors as $descriptor) {
+            if ($descriptor instanceof ExtendedDescriptor) {
+                $descriptor->setMetadata($pragmaCollector->getMetadata());
+            }
+        }
+
+        return $descriptors;
+    }
+
+    private function isPhpFile(string $filePath): bool
+    {
+        $extension = pathinfo($filePath, PATHINFO_EXTENSION);
+
+        return in_array($extension, self::PHP_PATH_EXTENSIONS);
+    }
+}

--- a/src/Extractor/Parser/Descriptor/PragmaCollectorVisitor.php
+++ b/src/Extractor/Parser/Descriptor/PragmaCollectorVisitor.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor\Parser\Descriptor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+use function count;
+use function preg_match;
+use function preg_match_all;
+
+/**
+ * A PhpParser\NodeVisitor that collects additional metadata from parsed source code
+ */
+class PragmaCollectorVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $parsedPragma = [];
+
+    private ?string $pragmaName;
+
+    public function __construct(string $pragmaName)
+    {
+        preg_match('/^[a-z0-9_\-]+$/', $pragmaName, $nameMatches);
+        $this->pragmaName = $nameMatches[0] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMetadata(): array
+    {
+        return $this->parsedPragma;
+    }
+
+    /**
+     * @return int | Node | null
+     */
+    public function enterNode(Node $node)
+    {
+        if ($this->pragmaName === null) {
+            return null;
+        }
+
+        $comments = $node->getComments();
+        if (count($comments) === 0) {
+            return null;
+        }
+
+        foreach ($comments as $comment) {
+            preg_match('/@' . $this->pragmaName . ' (.*)/', $comment->getText(), $pragmaMatches);
+            if (!isset($pragmaMatches[1])) {
+                continue;
+            }
+
+            preg_match_all('/(([a-z0-9_\-]+):([a-z0-9_\-]+))+/', $pragmaMatches[1], $propertyMatches);
+            foreach ($propertyMatches[2] as $index => $propertyName) {
+                $this->parsedPragma[$propertyName] = $propertyMatches[3][$index];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Extractor/Parser/DescriptorParser.php
+++ b/src/Extractor/Parser/DescriptorParser.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor\Parser;
+
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Intl\DescriptorCollection;
+
+/**
+ * Parses message descriptors from application source code files
+ */
+interface DescriptorParser
+{
+    /**
+     * @throws UnableToProcessFile
+     */
+    public function parse(string $filePath): DescriptorCollection;
+}

--- a/src/Extractor/Parser/Error.php
+++ b/src/Extractor/Parser/Error.php
@@ -22,21 +22,27 @@ declare(strict_types=1);
 
 namespace FormatPHP\Extractor\Parser;
 
-use FormatPHP\Exception\UnableToProcessFile;
-use FormatPHP\Intl\DescriptorCollection;
+use Throwable;
 
 /**
- * Parses message descriptors from application source code files
+ * An error that occurred while parsing application source code
  */
-interface DescriptorParser
+final class Error
 {
-    /**
-     * @throws UnableToProcessFile
-     */
-    public function parse(string $filePath): DescriptorCollection;
+    public string $message;
+    public string $sourceFile;
+    public int $sourceLine;
+    public ?Throwable $exception;
 
-    /**
-     * @return Error[]
-     */
-    public function getErrors(): array;
+    public function __construct(
+        string $message,
+        string $sourceFile,
+        int $sourceLine,
+        ?Throwable $exception = null
+    ) {
+        $this->message = $message;
+        $this->sourceFile = $sourceFile;
+        $this->sourceLine = $sourceLine;
+        $this->exception = $exception;
+    }
 }

--- a/tests/Extractor/Parser/Descriptor/PhpParserTest.php
+++ b/tests/Extractor/Parser/Descriptor/PhpParserTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Extractor\Parser\Descriptor;
+
+use FormatPHP\Extractor\Parser\Descriptor\PhpParser;
+use FormatPHP\Intl;
+use FormatPHP\Test\TestCase;
+use FormatPHP\Util\File;
+
+class PhpParserTest extends TestCase
+{
+    public function testParse01(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-01.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'This is a default message',
+                'description' => 'A simple description of a fixture for testing purposes.',
+                'end' => 202,
+                'file' => __DIR__ . '/fixtures/php-parser-01.php',
+                'id' => 'aTestId',
+                'line' => 3,
+                'meta' => [],
+                'start' => 44,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse02(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage', 'bar'], 'intl');
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-02.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'How are you?',
+                'description' => null,
+                'end' => 635,
+                'file' => __DIR__ . '/fixtures/php-parser-02.php',
+                'id' => 'greeting.question',
+                'line' => 28,
+                'meta' => [
+                    'some' => 'thing',
+                    'another' => 'meta-value',
+                    'another_property' => 'some_value',
+                    'and-still-more' => 'a-value',
+                ],
+                'start' => 536,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse03(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage', 'translate']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-03.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'Hello!',
+                'description' => null,
+                'end' => 310,
+                'file' => __DIR__ . '/fixtures/php-parser-03.php',
+                'id' => 'OpKKos',
+                'line' => 14,
+                'meta' => [],
+                'start' => 274,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse04(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage', 'translate', 'translate2', 'translate3']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-04.php');
+
+        $this->assertCount(0, $descriptors);
+    }
+
+    public function testParse05(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage'], 'invalid.pragma');
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-05.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'This is a default message',
+                'description' => 'A simple description of a fixture for testing purposes.',
+                'end' => 237,
+                'file' => __DIR__ . '/fixtures/php-parser-05.php',
+                'id' => 'aTestId',
+                'line' => 6,
+                'meta' => [],
+                'start' => 79,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse06(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage'], 'intl');
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-06.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'This is a default message',
+                'description' => 'A simple description of a fixture for testing purposes.',
+                'end' => 241,
+                'file' => __DIR__ . '/fixtures/php-parser-06.php',
+                'id' => 'aTestId',
+                'line' => 6,
+                'meta' => [],
+                'start' => 83,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse07WithoutPreservingWhitespace(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-07.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+                'description' => 'A description with multiple lines and extra whitespace.',
+                'end' => 394,
+                'file' => __DIR__ . '/fixtures/php-parser-07.php',
+                'id' => 'photos.count',
+                'line' => 4,
+                'meta' => [],
+                'start' => 49,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse07PreservingWhitespace(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage'], null, true);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-07.php');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(1, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertSame(
+            [
+                'defaultMessage' => "\nYou have {numPhotos, plural,\n    =0 {no photos.}\n"
+                    . "    =1 {one photo.}\n    other {# photos.}\n}\n",
+                'description' => "  A description with \n multiple lines    \n   and extra whitespace.   ",
+                'end' => 394,
+                'file' => __DIR__ . '/fixtures/php-parser-07.php',
+                'id' => 'photos.count',
+                'line' => 4,
+                'meta' => [],
+                'start' => 49,
+            ],
+            $descriptors[0]->toArray(),
+        );
+    }
+
+    public function testParse08(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-08.txt');
+
+        $this->assertCount(0, $descriptors);
+    }
+
+    public function testParse09(): void
+    {
+        $parser = new PhpParser(new File(), ['formatMessage']);
+        $descriptors = $parser->parse(__DIR__ . '/fixtures/php-parser-09.phtml');
+
+        $this->assertContainsOnlyInstancesOf(Intl\Descriptor::class, $descriptors);
+        $this->assertCount(2, $descriptors);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[0]);
+        $this->assertInstanceOf(Intl\ExtendedDescriptor::class, $descriptors[1]);
+        $this->assertSame(
+            [
+                'defaultMessage' => 'Welcome!',
+                'description' => null,
+                'end' => 277,
+                'file' => __DIR__ . '/fixtures/php-parser-09.phtml',
+                'id' => 'welcome',
+                'line' => 11,
+                'meta' => [],
+                'start' => 227,
+            ],
+            $descriptors[0]->toArray(),
+        );
+        $this->assertSame(
+            [
+                'defaultMessage' => 'Goodbye!',
+                'description' => null,
+                'end' => 419,
+                'file' => __DIR__ . '/fixtures/php-parser-09.phtml',
+                'id' => 'goodbye',
+                'line' => 15,
+                'meta' => [],
+                'start' => 369,
+            ],
+            $descriptors[1]->toArray(),
+        );
+    }
+}

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-01.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-01.php
@@ -1,0 +1,7 @@
+<?php
+
+$internationalization->formatMessage([
+    'id' => 'aTestId',
+    'defaultMessage' => 'This is a default message',
+    'description' => 'A simple description of a fixture for testing purposes.',
+]);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-02.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-02.php
@@ -5,6 +5,15 @@
 
 use FormatPHP\Intl;
 
+/**
+ * The following pragma annotation is empty on purpose
+ *
+ * @intl
+ *
+ * Just some sample comment text here.
+ * @intl more:details and:more
+ * More comments not part of the pragma.
+ */
 class Foo
 {
     private Intl $intl;

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-02.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-02.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @intl some:thing this should not be captured another:meta-value also not captured
+ */
+
+use FormatPHP\Intl;
+
+class Foo
+{
+    private Intl $intl;
+
+    /**
+     * @intl another_property:some_value
+     */
+    public function __construct()
+    {
+        $this->intl = new Intl('en', []);
+    }
+
+    public function bar(array $descriptor): string
+    {
+        // @intl and-still-more:a-value
+        return $this->intl->formatMessage($descriptor);
+    }
+
+    public function baz(): void
+    {
+        $translation = $this->bar([
+            'id' => 'greeting.question',
+            'defaultMessage' => 'How are you?',
+        ]);
+
+        echo $translation . "\n";
+    }
+}

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-03.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-03.php
@@ -1,0 +1,18 @@
+<?php
+
+use FormatPHP\Intl;
+
+function translate(array $descriptor): string {
+    $intl = new Intl('en', []);
+
+    return $intl->formatMessage($descriptor);
+}
+
+/**
+ * @intl name:value we didn't pass a pragma in the test, so this shouldn't show up
+ */
+$translation = translate([
+    'defaultMessage' => 'Hello!',
+]);
+
+echo $translation . "\n";

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-04.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-04.php
@@ -1,0 +1,30 @@
+<?php
+
+function translate(string $foo): string {
+    return $foo;
+}
+
+function formatMessage(string $foo): string {
+    return $foo;
+}
+
+function translate2(): void {
+    // do nothing
+}
+
+function translate3(array $something): void {
+    // do nothing
+}
+
+$foo = function (string $foo): string {
+    return $foo;
+};
+
+echo $foo('bar');
+
+$translation = translate('foo');
+
+translate2();
+translate3(['foo' => '123', null, 'bar']);
+
+echo $translation . "\n" . formatMessage('bar') . "\n";

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-04.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-04.php
@@ -16,6 +16,10 @@ function translate3(array $something): void {
     // do nothing
 }
 
+function translate4(array $descriptor): void {
+    // do nothing
+}
+
 $foo = function (string $foo): string {
     return $foo;
 };
@@ -26,5 +30,11 @@ $translation = translate('foo');
 
 translate2();
 translate3(['foo' => '123', null, 'bar']);
+
+translate4([
+    'id' => 'aTestId',
+    'defaultMessage' => 'This supposed to look like a formatMessage call, but it is not',
+    'description' => 'Sample text',
+]);
 
 echo $translation . "\n" . formatMessage('bar') . "\n";

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-05.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-05.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @invalid.pragma foo:bar
+ */
+$internationalization->formatMessage([
+    'id' => 'aTestId',
+    'defaultMessage' => 'This is a default message',
+    'description' => 'A simple description of a fixture for testing purposes.',
+]);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-06.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-06.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @no-matching-pragma foo:bar
+ */
+$internationalization->formatMessage([
+    'id' => 'aTestId',
+    'defaultMessage' => 'This is a default message',
+    'description' => 'A simple description of a fixture for testing purposes.',
+]);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-07.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-07.php
@@ -1,0 +1,20 @@
+<?php
+
+$internationalization->formatMessage(
+    [
+        'id' => 'photos.count',
+        'defaultMessage' => <<<EOM
+
+            You have {numPhotos, plural,
+                =0 {no photos.}
+                =1 {one photo.}
+                other {# photos.}
+            }
+
+            EOM,
+        'description' => "  A description with \n multiple lines    \n   and extra whitespace.   ",
+    ],
+    [
+        'numPhotos' => $photosCount,
+    ],
+);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-08.txt
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-08.txt
@@ -1,0 +1,10 @@
+This file is .txt, so the PHP parser will not parse it as PHP code, which is the
+point of this test.
+
+<?php
+
+$internationalization->formatMessage([
+    'id' => 'aTestId',
+    'defaultMessage' => 'This is a default message',
+    'description' => 'A simple description of a fixture for testing purposes.',
+]);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-09.phtml
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-09.phtml
@@ -15,5 +15,7 @@
         <p><?php echo $internationalization->formatMessage(['id' => 'goodbye', 'defaultMessage' => 'Goodbye!']); ?></p>
     </div>
 
+    <div><?=$internationalization->formatMessage();?></div>
+
 </body>
 </html>

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-09.phtml
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-09.phtml
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <title>An HTML page</title>
+</head>
+<body>
+
+    <p>This file is .phtml, so the PHP parser should parse it as PHP code.</p>
+
+    <div>
+        <p><?php echo $internationalization->formatMessage(['id' => 'welcome', 'defaultMessage' => 'Welcome!']); ?></p>
+    </div>
+
+    <div>
+        <p><?php echo $internationalization->formatMessage(['id' => 'goodbye', 'defaultMessage' => 'Goodbye!']); ?></p>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR includes a parser to parse the message descriptors from PHP source files. See the fixtures in `tests/Extractor/Parser/Descriptor/fixtures/` (included in this PR) for examples of the kind of source code this should be able to parse.

The parser extracts the descriptors from the source code, turning them into instances of `FormatPHP\Descriptor`.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
