### PR TITLE
feat: extract descriptors from source files and save as JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "nikic/php-parser": "^4.13",
+        "psr/log": "^2",
         "ramsey/collection": "^1.2",
         "webmozart/glob": "^4.4",
         "yiisoft/i18n": "^1.0"

--- a/src/Extractor/MessageExtractor.php
+++ b/src/Extractor/MessageExtractor.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor;
+
+use Closure;
+use FormatPHP\Exception\FormatPHPException;
+use FormatPHP\Exception\ImproperContext;
+use FormatPHP\Exception\InvalidArgument;
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Exception\UnableToWriteFile;
+use FormatPHP\Extractor\Parser\Descriptor\PhpParser;
+use FormatPHP\Extractor\Parser\DescriptorParser;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Util\File;
+use FormatPHP\Util\Globber;
+use FormatPHP\Writer\Formatter\FormatPHP;
+use FormatPHP\Writer\Formatter\Formatter;
+use FormatPHP\Writer\Formatter\Simple;
+use LogicException;
+use Psr\Log\LoggerInterface;
+
+use function assert;
+use function class_exists;
+use function count;
+use function fopen;
+use function is_a;
+use function is_callable;
+use function is_resource;
+use function json_encode;
+use function preg_replace;
+use function strtolower;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Extracts message descriptors from application source code
+ */
+class MessageExtractor
+{
+    private const JSON_ENCODE_FLAGS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+    private File $file;
+    private Globber $globber;
+    private LoggerInterface $logger;
+    private MessageExtractorOptions $options;
+
+    /**
+     * @var DescriptorParser[]
+     */
+    private array $parsers;
+
+    /**
+     * @throws LogicException
+     */
+    public function __construct(
+        MessageExtractorOptions $options,
+        LoggerInterface $logger,
+        Globber $globber,
+        File $file
+    ) {
+        $this->options = $options;
+        $this->logger = $logger;
+        $this->globber = $globber;
+        $this->file = $file;
+        $this->parsers = $this->loadParsers();
+    }
+
+    /**
+     * Processes the list of files according to the options set
+     *
+     * @param string[] $files
+     *
+     * @throws UnableToProcessFile
+     * @throws UnableToWriteFile
+     * @throws InvalidArgument
+     */
+    public function process(array $files): void
+    {
+        try {
+            $formatter = $this->getFormatter($this->options->format);
+        } catch (FormatPHPException $exception) {
+            $this->logger->error($exception->getMessage(), ['exception' => $exception]);
+
+            return;
+        }
+
+        $filesProcessed = 0;
+        $descriptors = new DescriptorCollection();
+
+        foreach ($this->globber->find($files, $this->options->ignore) as $path) {
+            $filesProcessed++;
+            $this->logger->debug('Extracting from {file}', ['file' => $path]);
+
+            try {
+                $descriptors = $this->parse($descriptors, $path);
+            } catch (UnableToProcessFile $exception) {
+                if ($this->options->throws === true) {
+                    throw $exception;
+                }
+
+                $this->logger->warning($exception->getMessage(), ['exception' => $exception]);
+            }
+        }
+
+        if ($filesProcessed === 0) {
+            $this->logger->warning('Could not find files', ['files' => $files]);
+
+            return;
+        }
+
+        $this->writeOutput($this->prepareOutput($formatter, $descriptors));
+    }
+
+    /**
+     * @throws UnableToProcessFile
+     */
+    private function parse(DescriptorCollection $descriptors, string $filePath): DescriptorCollection
+    {
+        foreach ($this->parsers as $parser) {
+            /** @var DescriptorCollection $descriptors */
+            $descriptors = $descriptors->merge($parser->parse($filePath));
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * @return DescriptorParser[]
+     *
+     * @throws LogicException
+     */
+    private function loadParsers(): array
+    {
+        $parsers = [];
+        $parsers[] = $this->getPhpParser();
+
+        return $parsers;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    private function getPhpParser(): PhpParser
+    {
+        return new PhpParser(
+            $this->file,
+            $this->options->additionalFunctionNames,
+            $this->options->pragma,
+            $this->options->preserveWhitespace,
+        );
+    }
+
+    /**
+     * @return callable(DescriptorCollection,MessageExtractorOptions):array<mixed>
+     *
+     * @throws ImproperContext
+     * @throws InvalidArgument
+     */
+    private function getFormatter(?string $format): callable
+    {
+        if ($format === null) {
+            return new FormatPHP();
+        }
+
+        switch (strtolower($format)) {
+            case 'simple':
+                return new Simple();
+            case 'formatjs':
+            case 'formatphp':
+                return new FormatPHP();
+        }
+
+        if (class_exists($format) && is_a($format, Formatter::class, true)) {
+            $formatter = new $format();
+        } else {
+            /** @var Closure(DescriptorCollection,MessageExtractorOptions):array<mixed> | null $formatter */
+            $formatter = $this->file->loadClosureFromScript($format);
+        }
+
+        if (is_callable($formatter)) {
+            return $formatter;
+        }
+
+        throw new InvalidArgument(
+            'The format provided is not a known format, an instance of '
+            . 'FormatPHP\\Writer\\Formatter\\Formatter, or a callable of the '
+            . 'shape `callable(\\FormatPHP\\Intl\\DescriptorCollection,'
+            . '\\FormatPHP\\Extractor\\MessageExtractorOptions):array<mixed>`.',
+        );
+    }
+
+    /**
+     * @param callable(DescriptorCollection,MessageExtractorOptions):array<mixed> $formatter
+     */
+    private function prepareOutput(callable $formatter, DescriptorCollection $descriptors): string
+    {
+        $messages = $formatter($descriptors, $this->options);
+
+        if (count($messages) === 0) {
+            $messages = (object) $messages;
+        }
+
+        $output = (string) json_encode($messages, self::JSON_ENCODE_FLAGS);
+
+        // Indent by 2 spaces instead of 4.
+        $output = (string) preg_replace('/^(  +?)\\1(?=[^ ])/m', '$1', $output);
+
+        return $output . "\n";
+    }
+
+    /**
+     * @throws UnableToWriteFile
+     * @throws InvalidArgument
+     */
+    private function writeOutput(string $output): void
+    {
+        if ($this->options->outFile !== null) {
+            $this->file->writeContents($this->options->outFile, $output);
+            $this->logger->notice(
+                'Message descriptors extracted and written to {file}',
+                ['file' => $this->options->outFile],
+            );
+
+            return;
+        }
+
+        $stream = fopen('php://output', 'w');
+        assert(is_resource($stream));
+
+        $this->file->writeContents($stream, $output);
+    }
+}

--- a/src/Extractor/MessageExtractorOptions.php
+++ b/src/Extractor/MessageExtractorOptions.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Extractor;
+
+/**
+ * MessageExtractor options
+ */
+class MessageExtractorOptions
+{
+    public ?string $format = null;
+    public ?string $outFile = null;
+    public string $idInterpolationPattern = IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN;
+    public bool $extractSourceLocation = false;
+    public bool $throws = false;
+    public ?string $pragma = null;
+    public bool $preserveWhitespace = false;
+
+    /**
+     * @var string[]
+     */
+    public array $additionalFunctionNames = [];
+
+    /**
+     * Glob file path patterns to ignore
+     *
+     * @var string[]
+     */
+    public array $ignore = [];
+}

--- a/src/Writer/Formatter/FormatPHP.php
+++ b/src/Writer/Formatter/FormatPHP.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Writer\Formatter;
+
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Intl\ExtendedDescriptor;
+
+use function array_merge;
+use function ksort;
+
+/**
+ * Default formatter for FormatPHP
+ *
+ * This follows the same format as the default formatter for FormatJS:
+ *
+ * ```json
+ * {
+ *   "my.message": {
+ *     "defaultMessage": "This is a message for translation.",
+ *     "description": "And I'm providing more details for translators here."
+ *   }
+ * }
+ * ```
+ *
+ * If `--extract-source-location` is provided, this will also include the
+ * following properties for each message:
+ *
+ * - `file` : The path to the source file where the descriptor is located.
+ * - `line` : The line in the source file where the descriptor starts.
+ * - `start` : The string offset (0-indexed) of the starting character of the descriptor in the source file.
+ * - `end` : The string offset (0-indexed) of the last character of the descriptor in the source file.
+ *
+ * If `--pragma` is provided, this will include a `meta` property with key-value
+ * pairs, according to the pragma parsed from each source file.
+ *
+ * @link https://formatjs.io/docs/getting-started/message-extraction FormatJS message extraction
+ */
+class FormatPHP implements Formatter
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke(DescriptorCollection $collection, MessageExtractorOptions $options): array
+    {
+        $format = [];
+
+        foreach ($collection as $item) {
+            $message = [];
+            $message['defaultMessage'] = $item->getDefaultMessage() ?? '';
+
+            if ($item->getDescription() !== null) {
+                $message['description'] = $item->getDescription();
+            }
+
+            if ($options->extractSourceLocation === true && $item instanceof ExtendedDescriptor) {
+                $message = array_merge($message, [
+                    'end' => $item->getSourceEndOffset(),
+                    'file' => $item->getSourceFile(),
+                    'line' => $item->getSourceLine(),
+                    'start' => $item->getSourceStartOffset(),
+                ]);
+            }
+
+            if ($options->pragma !== null && $item instanceof ExtendedDescriptor) {
+                $message = array_merge($message, [
+                    'meta' => $item->getMetadata(),
+                ]);
+            }
+
+            ksort($message);
+
+            $format[(string) $item->getId()] = $message;
+        }
+
+        return $format;
+    }
+}

--- a/src/Writer/Formatter/Formatter.php
+++ b/src/Writer/Formatter/Formatter.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Writer\Formatter;
+
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+
+interface Formatter
+{
+    /**
+     * @return mixed[]
+     */
+    public function __invoke(DescriptorCollection $collection, MessageExtractorOptions $options): array;
+}

--- a/src/Writer/Formatter/Simple.php
+++ b/src/Writer/Formatter/Simple.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Writer\Formatter;
+
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+
+/**
+ * A simple formatter for FormatPHP, producing message key-value pairs
+ *
+ * This follows the same format as the simple formatter for FormatJS:
+ *
+ * ```json
+ * {
+ *   "my.message": "This is a message for translation."
+ * }
+ * ```
+ */
+class Simple implements Formatter
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke(DescriptorCollection $collection, MessageExtractorOptions $options): array
+    {
+        $simple = [];
+        foreach ($collection as $item) {
+            $simple[(string) $item->getId()] = $item->getDefaultMessage();
+        }
+
+        return $simple;
+    }
+}

--- a/tests/Extractor/CustomFormatter.php
+++ b/tests/Extractor/CustomFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Extractor;
+
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Writer\Formatter\Formatter;
+
+class CustomFormatter implements Formatter
+{
+    /**
+     * @inheritdoc
+     */
+    public function __invoke(DescriptorCollection $collection, MessageExtractorOptions $options): array
+    {
+        $format = [];
+        foreach ($collection as $item) {
+            $format[(string) $item->getId()] = [
+                'id' => (string) $item->getId(),
+                'string' => $item->getDefaultMessage(),
+            ];
+        }
+
+        return $format;
+    }
+}

--- a/tests/Extractor/MessageExtractorTest.php
+++ b/tests/Extractor/MessageExtractorTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Extractor;
+
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Extractor\MessageExtractor;
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Test\TestCase;
+use FormatPHP\Util\File;
+use FormatPHP\Util\Globber;
+use Generator;
+use Hamcrest\Type\IsResource;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+use function json_decode;
+use function ob_end_clean;
+use function ob_get_contents;
+use function ob_start;
+
+class MessageExtractorTest extends TestCase
+{
+    public function testProcessWhenNoFilesAreFound(): void
+    {
+        $options = new MessageExtractorOptions();
+
+        $globber = $this->mockery(Globber::class);
+        $globber->shouldReceive('find')->andReturnUsing(function (): Generator {
+            // @phpstan-ignore-next-line
+            foreach ([] as $item) {
+                yield $item;
+            }
+        });
+
+        $file = $this->mockery(File::class);
+
+        $logger = $this->mockery(LoggerInterface::class);
+        $logger->expects()->warning('Could not find files', ['files' => ['foo', 'bar', 'baz']]);
+
+        $extractor = new MessageExtractor($options, $logger, $globber, $file);
+        $extractor->process(['foo', 'bar', 'baz']);
+    }
+
+    public function testProcessBasic(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage', 'translate'];
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.ph*']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $messages = json_decode((string) $output, true);
+
+        $this->assertSame(
+            [
+                'aTestId' => [
+                    'defaultMessage' => 'This is a default message',
+                    'description' => 'A simple description of a fixture for testing purposes.',
+                ],
+                'OpKKos' => [
+                    'defaultMessage' => 'Hello!',
+                ],
+                'photos.count' => [
+                    'defaultMessage' =>
+                        'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+                    'description' => 'A description with multiple lines and extra whitespace.',
+                ],
+                'welcome' => [
+                    'defaultMessage' => 'Welcome!',
+                ],
+                'goodbye' => [
+                    'defaultMessage' => 'Goodbye!',
+                ],
+            ],
+            $messages,
+        );
+    }
+
+    public function testProcessWithFormatPhpFormatterName(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->format = 'FormatPHP';
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $messages = json_decode((string) $output, true);
+
+        $this->assertSame(
+            [
+                'aTestId' => [
+                    'defaultMessage' => 'This is a default message',
+                    'description' => 'A simple description of a fixture for testing purposes.',
+                ],
+                'photos.count' => [
+                    'defaultMessage' =>
+                        'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+                    'description' => 'A description with multiple lines and extra whitespace.',
+                ],
+            ],
+            $messages,
+        );
+    }
+
+    public function testProcessWithSimpleFormatterName(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->format = 'simple';
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $messages = json_decode((string) $output, true);
+
+        $this->assertSame(
+            [
+                'aTestId' => 'This is a default message',
+                'photos.count' => 'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+            ],
+            $messages,
+        );
+    }
+
+    public function testProcessWithCustomFormatterClass(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->format = CustomFormatter::class;
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $messages = json_decode((string) $output, true);
+
+        $this->assertSame(
+            [
+                'aTestId' => [
+                    'id' => 'aTestId',
+                    'string' => 'This is a default message',
+                ],
+                'photos.count' => [
+                    'id' => 'photos.count',
+                    'string' => 'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+                ],
+            ],
+            $messages,
+        );
+    }
+
+    public function testProcessWithExternalFormatterScript(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->format = __DIR__ . '/format.php';
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $messages = json_decode((string) $output, true);
+
+        $this->assertSame(
+            [
+                'aTestId' => [
+                    'translation' => 'This is a default message',
+                ],
+                'photos.count' => [
+                    'translation' => 'You have {numPhotos, plural, =0 {no photos.} =1 {one photo.} other {# photos.} }',
+                ],
+            ],
+            $messages,
+        );
+    }
+
+    public function testProcessLogsErrorForInvalidFormatter(): void
+    {
+        $logger = $this->mockery(LoggerInterface::class);
+        $logger->shouldReceive('error')->withArgs(function (string $message): bool {
+            $expected = 'The format provided is not a known format, an instance of '
+            . 'FormatPHP\\Writer\\Formatter\\Formatter, or a callable of the '
+            . 'shape `callable(\\FormatPHP\\Intl\\DescriptorCollection,'
+            . '\\FormatPHP\\Extractor\\MessageExtractorOptions):array<mixed>`.';
+
+            return $message === $expected;
+        });
+
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->format = 'this-is-not-a-valid-formatter';
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        ob_end_clean();
+    }
+
+    public function testProcessWithNoResults(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['notExistentFunction'];
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), new File());
+
+        ob_start();
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+        $output = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertStringContainsString('{}', (string) $output);
+    }
+
+    public function testProcessWritesToFile(): void
+    {
+        $logger = new NullLogger();
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['notExistentFunction'];
+        $options->outFile = 'en-US.json';
+
+        $file = $this->mockery(File::class);
+        $file->shouldReceive('getContents')->andReturn('nothing of consequence');
+        $file->expects()->writeContents('en-US.json', "{}\n");
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), $file);
+        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.php']);
+    }
+
+    public function testProcessWhenUnableToProcessFile(): void
+    {
+        $path = __DIR__ . '/Parser/Descriptor/fixtures/php-parser-01.php';
+
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+
+        $exception = new UnableToProcessFile('something bad happened');
+
+        $file = $this->mockery(File::class);
+        $file->expects()->getContents($path)->andThrows($exception);
+        $file->expects()->writeContents(new IsResource(), "{}\n");
+
+        $logger = $this->mockery(LoggerInterface::class);
+        $logger->shouldReceive('debug')->with(
+            'Extracting from {file}',
+            ['file' => $path],
+        );
+        $logger->shouldReceive('warning')->with(
+            'something bad happened',
+            ['exception' => $exception],
+        );
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), $file);
+        $extractor->process([$path]);
+    }
+
+    public function testProcessWhenUnableToProcessFileThrowsException(): void
+    {
+        $path = __DIR__ . '/Parser/Descriptor/fixtures/php-parser-01.php';
+
+        $options = new MessageExtractorOptions();
+        $options->additionalFunctionNames = ['formatMessage'];
+        $options->throws = true;
+
+        $exception = new UnableToProcessFile('something bad happened');
+
+        $file = $this->mockery(File::class);
+        $file->expects()->getContents($path)->andThrows($exception);
+
+        $logger = $this->mockery(LoggerInterface::class);
+        $logger->shouldReceive('debug')->with(
+            'Extracting from {file}',
+            ['file' => $path],
+        );
+
+        $extractor = new MessageExtractor($options, $logger, new Globber(new File()), $file);
+
+        $this->expectException(UnableToProcessFile::class);
+        $this->expectExceptionMessage('something bad happened');
+
+        $extractor->process([$path]);
+    }
+}

--- a/tests/Extractor/format.php
+++ b/tests/Extractor/format.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This is a test formatter
+ */
+
+declare(strict_types=1);
+
+use FormatPHP\Intl\DescriptorCollection;
+
+/**
+ * @return array<string, array{translation: string}>
+ */
+return function (DescriptorCollection $collection): array {
+    $format = [];
+    foreach ($collection as $item) {
+        $format[(string) $item->getId()] = [
+            'translation' => $item->getDefaultMessage(),
+        ];
+    }
+
+    return $format;
+};

--- a/tests/Writer/Formatter/FormatPHPTest.php
+++ b/tests/Writer/Formatter/FormatPHPTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Writer\Formatter;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Test\TestCase;
+use FormatPHP\Writer\Formatter\FormatPHP;
+
+class FormatPHPTest extends TestCase
+{
+    public function testFormatterBasic(): void
+    {
+        $options = new MessageExtractorOptions();
+
+        $collection = new DescriptorCollection();
+        $collection->add(new Descriptor('foo'));
+        $collection->add(new Descriptor('bar', 'some message'));
+        $collection->add(new Descriptor('baz', 'another message', 'a description'));
+
+        $formatter = new FormatPHP();
+
+        $this->assertSame(
+            [
+                'foo' => ['defaultMessage' => ''],
+                'bar' => ['defaultMessage' => 'some message'],
+                'baz' => ['defaultMessage' => 'another message', 'description' => 'a description'],
+            ],
+            $formatter($collection, $options),
+        );
+    }
+
+    public function testFormatterFull(): void
+    {
+        $options = new MessageExtractorOptions();
+        $options->extractSourceLocation = true;
+        $options->pragma = 'intl';
+
+        $descriptor = new Descriptor(
+            'foo',
+            'my default message',
+            'my description',
+            '/path/to/file.php',
+            45,
+            96,
+            13,
+        );
+
+        $descriptor->setMetadata([
+            'aaa' => 'some-value',
+            'bbb' => 'another-value',
+        ]);
+
+        $collection = new DescriptorCollection();
+        $collection->add($descriptor);
+
+        $formatter = new FormatPHP();
+
+        $this->assertSame(
+            [
+                'foo' => [
+                    'defaultMessage' => 'my default message',
+                    'description' => 'my description',
+                    'end' => 96,
+                    'file' => '/path/to/file.php',
+                    'line' => 13,
+                    'meta' => [
+                        'aaa' => 'some-value',
+                        'bbb' => 'another-value',
+                    ],
+                    'start' => 45,
+                ],
+            ],
+            $formatter($collection, $options),
+        );
+    }
+}

--- a/tests/Writer/Formatter/SimpleTest.php
+++ b/tests/Writer/Formatter/SimpleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Writer\Formatter;
+
+use FormatPHP\Descriptor;
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Intl\DescriptorCollection;
+use FormatPHP\Test\TestCase;
+use FormatPHP\Writer\Formatter\Simple;
+
+class SimpleTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        $collection = new DescriptorCollection();
+        $collection->add(new Descriptor('aaa', 'first message', 'a description'));
+        $collection->add(new Descriptor('bbb', 'second message', 'another description'));
+
+        $this->assertSame(
+            [
+                'aaa' => 'first message',
+                'bbb' => 'second message',
+            ],
+            (new Simple())($collection, new MessageExtractorOptions()),
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This is the primary message extraction workhorse. It uses the PHP parser in #6 to parse descriptors from PHP source files. These are then written to a JSON file using the formatters provided in this PR or via the command line (see #5).

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
