### PR TITLE
feat: include a console application for extracting messages

### DIFF
--- a/bin/formatphp
+++ b/bin/formatphp
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Console;
+
+use Symfony\Component\Console\Input\ArgvInput;
+
+use function file_exists;
+use function fwrite;
+
+(static function (array $argv): void {
+    $composerAutoloadLocations = [
+        __DIR__ . '/../autoload.php',
+        __DIR__ . '/../vendor/autoload.php',
+        __DIR__ . '/../../../autoload.php',
+    ];
+
+    foreach ($composerAutoloadLocations as $file) {
+        if (file_exists($file)) {
+            $composerAutoloader = $file;
+
+            break;
+        }
+    }
+
+    unset($file);
+
+    if (!isset($composerAutoloader)) {
+        fwrite(
+            STDERR,
+            'To execute this command, please install Composer and run \'composer install\'.' . PHP_EOL
+            . 'For more information, go to https://getcomposer.org' . PHP_EOL,
+        );
+
+        exit(1);
+    }
+
+    /** @psalm-suppress UnresolvableInclude */
+    require $composerAutoloader;
+
+    (new Application())->run(new ArgvInput($argv));
+})($argv);

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "nikic/php-parser": "^4.13",
         "psr/log": "^2",
         "ramsey/collection": "^1.2",
+        "symfony/console": "^5.3",
         "webmozart/glob": "^4.4",
         "yiisoft/i18n": "^1.0"
     },
@@ -53,5 +54,8 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "bin": [
+        "bin/formatphp"
+    ]
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Console;
+
+use FormatPHP\Console\Command\ExtractCommand;
+use Symfony\Component\Console\Application as SymfonyConsoleApplication;
+
+/**
+ * @internal
+ */
+class Application extends SymfonyConsoleApplication
+{
+    public const NAME = 'formatphp';
+
+    public function __construct()
+    {
+        parent::__construct(self::NAME);
+
+        $this->add(new ExtractCommand());
+    }
+}

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Console\Command;
+
+use Symfony\Component\Console\Command\Command as SymfonyConsoleCommand;
+
+/**
+ * @internal
+ */
+abstract class Command extends SymfonyConsoleCommand
+{
+}

--- a/src/Console/Command/ExtractCommand.php
+++ b/src/Console/Command/ExtractCommand.php
@@ -1,0 +1,224 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Console\Command;
+
+use FormatPHP\Exception\UnableToProcessFile;
+use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Extractor\MessageExtractor;
+use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Util\File;
+use FormatPHP\Util\Globber;
+use LogicException;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_map;
+use function array_merge;
+use function explode;
+use function getcwd;
+
+/**
+ * Provides the `formatphp extract` command
+ *
+ * @internal
+ */
+class ExtractCommand extends Command
+{
+    private const DEFAULT_FUNCTION_NAMES = ['formatMessage'];
+
+    private const STANDARD_IGNORES = [
+        '.arch-params',
+        '.bzr',
+        '.git',
+        '.hg',
+        '.idea',
+        '.monotone',
+        '.svn',
+        '.vscode',
+        '_darcs',
+        '_svn',
+        'CVS',
+        'node_modules',
+        'vendor',
+    ];
+
+    private const LOG_FORMAT_MAPPING = [
+        LogLevel::WARNING => ConsoleLogger::ERROR,
+        LogLevel::NOTICE => ConsoleLogger::ERROR,
+        LogLevel::INFO => ConsoleLogger::ERROR,
+        LogLevel::DEBUG => ConsoleLogger::ERROR,
+    ];
+
+    private const LOG_VERBOSITY_MAPPING = [
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+    ];
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('extract')
+            ->setDescription('Extract string messages from application source code')
+            ->addArgument(
+                'files',
+                InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+                'One or more paths to process for extraction. May use glob '
+                    . 'patterns for file matching; supports globstar (`**`) '
+                    . 'for recursive matching.',
+            )
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Formatter name or path to a formatter script that controls '
+                    . 'the shape of the JSON produced for `--out-file`.',
+            )
+            ->addOption(
+                'out-file',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Target file path to save the JSON output file of all '
+                    . 'translations extracted from the `files`.',
+            )
+            ->addOption(
+                'id-interpolation-pattern',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'If message descriptors are missing the id property, we will '
+                    . 'use this pattern to automatically generate IDs for '
+                    . 'them. Defaults to `[sha512:contenthash:base64:6]` where '
+                    . '`contenthash` represents the hash of `defaultMessage` '
+                    . 'and `description`.',
+            )
+            ->addOption(
+                'extract-source-location',
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to extract metadata for the source files. If present, '
+                    . 'the extracted descriptors will each include `file`, '
+                    . '`start`, `end`, `line`, and `col` properties.',
+            )
+            ->addOption(
+                'additional-function-names',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Comma-separated list of additional function names to search '
+                    . 'for when extracting messages.',
+            )
+            ->addOption(
+                'ignore',
+                null,
+                InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+                'Glob patterns for paths to exclude from extraction.',
+            )
+            ->addOption(
+                'throws',
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to throw an exception when failing to process any '
+                    . 'file in the batch.',
+            )
+            ->addOption(
+                'pragma',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Allows parsing of additional custom pragma to include custom '
+                    . 'metadata in the extracted messages.',
+            )
+            ->addOption(
+                'preserve-whitespace',
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to preserve whitespace and newlines in extracted '
+                    . 'messages.',
+            );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws UnableToProcessFile
+     * @throws LogicException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string[] $files */
+        $files = $input->getArgument('files') ?: [getcwd() . '/**/*'];
+        $options = $this->buildOptions($input);
+
+        $extractor = new MessageExtractor(
+            $options,
+            new ConsoleLogger($output, self::LOG_VERBOSITY_MAPPING, self::LOG_FORMAT_MAPPING),
+            new Globber(new File()),
+            new File(),
+        );
+
+        $extractor->process($files);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function buildOptions(InputInterface $input): MessageExtractorOptions
+    {
+        $options = new MessageExtractorOptions();
+
+        /** @var string | null $format */
+        $format = $input->getOption('format');
+        $options->format = $format;
+
+        /** @var string | null $outFile */
+        $outFile = $input->getOption('out-file');
+        $options->outFile = $outFile;
+
+        /** @var string | null $idInterpolationPattern */
+        $idInterpolationPattern = $input->getOption('id-interpolation-pattern');
+        $options->idInterpolationPattern = $idInterpolationPattern ?? IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN;
+
+        /** @var string[] $ignore */
+        $ignore = (array) $input->getOption('ignore');
+        $options->ignore = array_merge(self::STANDARD_IGNORES, $ignore);
+
+        /** @var string | null $pragma */
+        $pragma = $input->getOption('pragma');
+        $options->pragma = $pragma;
+
+        $options->extractSourceLocation = (bool) $input->getOption('extract-source-location');
+        $options->throws = (bool) $input->getOption('throws');
+        $options->preserveWhitespace = (bool) $input->getOption('preserve-whitespace');
+        $options->additionalFunctionNames = array_merge(
+            self::DEFAULT_FUNCTION_NAMES,
+            array_map('trim', explode(',', (string) $input->getOption('additional-function-names'))),
+        );
+
+        return $options;
+    }
+}

--- a/tests/Console/Command/ExtractCommandTest.php
+++ b/tests/Console/Command/ExtractCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test\Console\Command;
+
+use FormatPHP\Console\Application;
+use FormatPHP\Console\Command\ExtractCommand;
+use FormatPHP\Test\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ExtractCommandTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $application = new Application();
+
+        /** @var ExtractCommand $command */
+        $command = $application->find('extract');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['files' => ['*.foo']]);
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString(
+            '[warning] Could not find files',
+            $output,
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR wraps up the initial work on FormatPHP. With it, we now have a CLI command to extract messages from PHP source code.

Given PHP source code like this:

```php
$locale = new \FormatPHP\Locale('fr');
$messages = new \FormatPHP\Intl\MessageCollection([
    new \FormatPHP\Message($locale, 'myMessage', "Aujourd'hui, c'est le {ts, date, ::yyyyMMdd}"),
]);

$intl = new \FormatPHP\Intl($locale, $messages);

echo $intl->formatMessage(
    [
        'id' => 'myMessage',
        'defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}',
    ],
    [
        'ts' => time(),
    ],
);
```

When we run this:

```shell
formatphp extract 'src/**/*.php'
```

It produces this:

```json
{
  "myMessage": {
    "defaultMessage": "Today is {ts, date, ::yyyyMMdd}"
  }
}
```

Also, running the script above as-is produces this:

```
Aujourd'hui, c'est le 02/11/2021
```

However, a future improvement to this library will include a loader to load messages from language files.

Take a look at the CLI help output:

```shell
formatphp extract --help
```

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-34756

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
