### PR TITLE
feat: bring Locale to parity with FormatJS and ECMA-402

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "psr/log": "^2",
         "ramsey/collection": "^1.2",
         "symfony/console": "^5.3",
-        "webmozart/glob": "^4.4",
-        "yiisoft/i18n": "^1.0"
+        "symfony/polyfill-php80": "^1.23",
+        "webmozart/glob": "^4.4"
     },
     "require-dev": {
         "ramsey/devtools": "^1.7"

--- a/src/Intl/Locale.php
+++ b/src/Intl/Locale.php
@@ -22,36 +22,283 @@ declare(strict_types=1);
 
 namespace FormatPHP\Intl;
 
+use BadMethodCallException;
 use FormatPHP\Exception\InvalidArgumentException;
-use InvalidArgumentException as PhpInvalidArgumentException;
-use Yiisoft\I18n\Locale as YiiLocale;
+use Locale as PhpLocale;
+
+use function array_filter;
+use function array_values;
+use function implode;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function strtolower;
 
 /**
- * FormatPHP locale
+ * An implementation of an ECMA-402 locale identifier
  */
 class Locale implements LocaleInterface
 {
-    private YiiLocale $locale;
+    private const UNDEFINED_LOCALE = 'und';
+
+    /**
+     * @var array{language: string | null, script: string | null, region: string | null, variants: array<string>, keywords: array<string, string>, grandfathered: string | null}
+     */
+    private array $parsedLocale = [
+        'language' => null,
+        'script' => null,
+        'region' => null,
+        'variants' => [],
+        'keywords' => [],
+        'grandfathered' => null,
+    ];
 
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(string $locale)
+    public function __construct(string $locale, ?LocaleOptions $options = null)
     {
-        try {
-            $this->locale = new YiiLocale($locale);
-        } catch (PhpInvalidArgumentException $exception) {
-            throw new InvalidArgumentException($exception->getMessage(), (int) $exception->getCode(), $exception);
+        if (strtolower($locale) === self::UNDEFINED_LOCALE) {
+            $locale = PhpLocale::getDefault();
+        }
+
+        $canonicalizedLocale = PhpLocale::canonicalize($locale);
+
+        /** @var array{language?: string, script?: string, region?: string, grandfathered?: string} $parsed */
+        $parsed = PhpLocale::parseLocale($canonicalizedLocale);
+        if ($parsed === []) {
+            throw new InvalidArgumentException(sprintf('Unable to parse "%s" as a valid locale string', $locale));
+        }
+
+        /** @var array<string, string> $keywords */
+        $keywords = PhpLocale::getKeywords($canonicalizedLocale) ?: [];
+        $variants = [];
+
+        foreach ($parsed as $key => $value) {
+            if (!str_starts_with($key, 'variant')) {
+                continue;
+            }
+
+            $variants[] = $value;
+        }
+
+        $this->parsedLocale['language'] = $parsed['language'] ?? self::UNDEFINED_LOCALE;
+        $this->parsedLocale['script'] = $parsed['script'] ?? null;
+        $this->parsedLocale['region'] = $parsed['region'] ?? null;
+        $this->parsedLocale['grandfathered'] = $parsed['grandfathered'] ?? null;
+        $this->parsedLocale['variants'] = $variants;
+        $this->parsedLocale['keywords'] = $keywords;
+
+        if ($options !== null) {
+            $this->applyOptions($options);
         }
     }
 
-    public function getId(): string
+    public function baseName(): ?string
     {
-        return $this->locale->asString();
+        if (!$this->parsedLocale['language']) {
+            return '';
+        }
+
+        $parts = [
+            $this->parsedLocale['language'],
+            $this->parsedLocale['script'],
+            $this->parsedLocale['region'],
+            ...array_values($this->parsedLocale['variants']),
+        ];
+
+        return implode('-', array_filter($parts));
     }
 
-    public function getFallbackLocale(): LocaleInterface
+    public function calendar(): ?string
     {
-        return new self($this->locale->fallbackLocale()->asString());
+        // Ensure return values conform to the expected values for ECMA-402.
+        switch ($this->parsedLocale['keywords']['calendar'] ?? null) {
+            case 'ethiopic-amete-alem':
+                return 'ethioaa';
+            case 'gregorian':
+                return 'gregory';
+        }
+
+        return $this->parsedLocale['keywords']['calendar'] ?? null;
+    }
+
+    public function caseFirst(): ?string
+    {
+        // ECMA-402 expects the string "false," instead of "no."
+        if (($this->parsedLocale['keywords']['colcasefirst'] ?? null) === 'no') {
+            return 'false';
+        }
+
+        /** @var "upper" | "lower" | null */
+        return $this->parsedLocale['keywords']['colcasefirst'] ?? null;
+    }
+
+    public function collation(): ?string
+    {
+        // Ensure return values conform to the expected values for ECMA-402.
+        switch ($this->parsedLocale['keywords']['collation'] ?? null) {
+            case 'dictionary':
+                return 'dict';
+            case 'gb2312han':
+                return 'gb2312';
+            case 'phonebook':
+                return 'phonebk';
+            case 'traditional':
+                return 'trad';
+        }
+
+        return $this->parsedLocale['keywords']['collation'] ?? null;
+    }
+
+    public function hourCycle(): ?string
+    {
+        /** @var "h11" | "h12" | "h23" | "h24" | null */
+        return $this->parsedLocale['keywords']['hours'] ?? null;
+    }
+
+    public function language(): ?string
+    {
+        return $this->parsedLocale['language'] ?? null;
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws BadMethodCallException
+     */
+    public function maximize(): LocaleInterface
+    {
+        throw new BadMethodCallException('Method not implemented');
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws BadMethodCallException
+     */
+    public function minimize(): LocaleInterface
+    {
+        throw new BadMethodCallException('Method not implemented');
+    }
+
+    public function numberingSystem(): ?string
+    {
+        // ECMA-402 expects "traditio," instead of "traditional."
+        if (($this->parsedLocale['keywords']['numbers'] ?? null) === 'traditional') {
+            return 'traditio';
+        }
+
+        return $this->parsedLocale['keywords']['numbers'] ?? null;
+    }
+
+    public function numeric(): bool
+    {
+        return ($this->parsedLocale['keywords']['colnumeric'] ?? null) === 'yes';
+    }
+
+    public function region(): ?string
+    {
+        return $this->parsedLocale['region'] ?? null;
+    }
+
+    public function script(): ?string
+    {
+        return $this->parsedLocale['script'] ?? null;
+    }
+
+    public function toString(): string
+    {
+        $locale = (string) $this->baseName();
+
+        $keywords = '';
+        foreach ($this->parsedLocale['keywords'] as $keyword => $value) {
+            $keyAndValue = $this->getUnicodeKeywordWithValue($keyword, $value);
+            if ($keyAndValue[1] !== null) {
+                $keywords .= "-$keyAndValue[0]-$keyAndValue[1]";
+            }
+        }
+
+        if (strlen($keywords) > 0) {
+            $locale .= '-u' . $keywords;
+        }
+
+        return $locale;
+    }
+
+    private function applyOptions(LocaleOptions $options): void
+    {
+        if ($options->calendar !== null) {
+            $this->parsedLocale['keywords']['calendar'] = $options->calendar;
+        }
+
+        if ($options->caseFirst !== null) {
+            $this->parsedLocale['keywords']['colcasefirst'] = $options->caseFirst;
+        }
+
+        if ($options->collation !== null) {
+            $this->parsedLocale['keywords']['collation'] = $options->collation;
+        }
+
+        if ($options->hourCycle !== null) {
+            $this->parsedLocale['keywords']['hours'] = $options->hourCycle;
+        }
+
+        if ($options->language !== null) {
+            $this->parsedLocale['language'] = $options->language;
+        }
+
+        if ($options->numberingSystem !== null) {
+            $this->parsedLocale['keywords']['numbers'] = $options->numberingSystem;
+        }
+
+        if ($options->numeric !== null) {
+            $this->parsedLocale['keywords']['colnumeric'] = $options->numeric ? 'yes' : 'no';
+        }
+
+        if ($options->region !== null) {
+            $this->parsedLocale['region'] = $options->region;
+        }
+
+        if ($options->script !== null) {
+            $this->parsedLocale['script'] = $options->script;
+        }
+    }
+
+    /**
+     * @return array{0: string, 1: string | null}
+     */
+    private function getUnicodeKeywordWithValue(string $keyword, string $defaultValue): array
+    {
+        switch ($keyword) {
+            case 'calendar':
+                return ['ca', $this->calendar()];
+            case 'colcasefirst':
+                return ['kf', $this->caseFirst()];
+            case 'collation':
+                return ['co', $this->collation()];
+            case 'hours':
+                return ['hc', $this->hourCycle()];
+            case 'numbers':
+                return ['nu', $this->numberingSystem()];
+            case 'colnumeric':
+                return ['kn', $this->numericValue()];
+        }
+
+        return [$keyword, $defaultValue];
+    }
+
+    private function numericValue(): ?string
+    {
+        $colnumeric = $this->parsedLocale['keywords']['colnumeric'] ?? null;
+
+        switch ($colnumeric) {
+            case 'yes':
+                return 'true';
+            case 'no':
+                return 'false';
+        }
+
+        return null;
     }
 }

--- a/src/Intl/LocaleInterface.php
+++ b/src/Intl/LocaleInterface.php
@@ -23,22 +23,84 @@ declare(strict_types=1);
 namespace FormatPHP\Intl;
 
 /**
- * FormatPHP locale
+ * An ECMA-402 locale identifier
+ *
+ * This defines an interface for PHP that conforms to Intl.Locale defined in the
+ * ECMAScript 2022 Internationalization API Specification (ECMA-402 9th Edition).
+ *
+ * @link https://tc39.es/ecma402/#locale-objects
  */
 interface LocaleInterface
 {
     /**
-     * Returns the identifier for this locale (i.e., "en," "pt-BR," etc.)
-     *
-     * The identifier is also known as a language tag.
+     * Returns a substring of this locale that provides basic locale information
      */
-    public function getId(): string;
+    public function baseName(): ?string;
 
     /**
-     * Returns a suitable fallback locale for this locale
-     *
-     * For example, if this locale is "en-US," a suitable fallback locale might
-     * be "en."
+     * Returns this locale's calendar era
      */
-    public function getFallbackLocale(): self;
+    public function calendar(): ?string;
+
+    /**
+     * Returns whether case is accounted for in this locale's collation rules
+     *
+     * @psalm-return "upper" | "lower" | "false" | null
+     */
+    public function caseFirst(): ?string;
+
+    /**
+     * Returns this locale's collation type
+     */
+    public function collation(): ?string;
+
+    /**
+     * Returns this locale's time-keeping convention
+     *
+     * @psalm-return "h11" | "h12" | "h23" | "h24" | null
+     */
+    public function hourCycle(): ?string;
+
+    /**
+     * Returns this locale's language
+     */
+    public function language(): ?string;
+
+    /**
+     * Using the existing values set on this locale instance, returns the most
+     * likely values that can be determined for language, script, and region
+     */
+    public function maximize(): LocaleInterface;
+
+    /**
+     * Removes any information from the locale that would be added by calling
+     * maximize()
+     */
+    public function minimize(): LocaleInterface;
+
+    /**
+     * Returns this locale's numeral system
+     */
+    public function numberingSystem(): ?string;
+
+    /**
+     * Returns whether this locale has special collation handling for
+     * numeric strings
+     */
+    public function numeric(): bool;
+
+    /**
+     * Returns this locale's region
+     */
+    public function region(): ?string;
+
+    /**
+     * Returns this locale's script used for writing
+     */
+    public function script(): ?string;
+
+    /**
+     * Returns the full string identifier for this locale
+     */
+    public function toString(): string;
 }

--- a/src/Intl/LocaleOptions.php
+++ b/src/Intl/LocaleOptions.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of skillshare/formatphp
+ *
+ * skillshare/formatphp is open source software: you can distribute
+ * it and/or modify it under the terms of the MIT License
+ * (the "License"). You may not use this file except in
+ * compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * @copyright Copyright (c) Skillshare, Inc. <https://www.skillshare.com>
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace FormatPHP\Intl;
+
+/**
+ * Configuration options for the locale identifier
+ */
+class LocaleOptions
+{
+    /**
+     * The locale's calendar era
+     */
+    public ?string $calendar = null;
+
+    /**
+     * Whether case should be accounted for in the locale's collation rules
+     * (i.e. `"upper"`, `"lower"`, or `"false"`)
+     *
+     * @psalm-var "upper" | "lower" | "false"
+     */
+    public ?string $caseFirst = null;
+
+    /**
+     * The locale's collation type
+     */
+    public ?string $collation = null;
+
+    /**
+     * The locale's time-keeping convention (i.e., `"h11"`, `"h12"`, `"h23"`,
+     * or `"h24"`)
+     *
+     * @psalm-var "h11" | "h12" | "h23" | "h24" | null
+     */
+    public ?string $hourCycle = null;
+
+    /**
+     * The locale's language
+     */
+    public ?string $language = null;
+
+    /**
+     * The locale's numeral system
+     */
+    public ?string $numberingSystem = null;
+
+    /**
+     * Whether the locale has special collation handling for numeric strings
+     */
+    public ?bool $numeric = null;
+
+    /**
+     * The locale's region
+     */
+    public ?string $region = null;
+
+    /**
+     * The locale's script used for writing
+     */
+    public ?string $script = null;
+
+    /**
+     * @param string | null $calendar The locale's calendar era
+     * @param string | null $caseFirst Whether case should be accounted for in
+     *     the locale's collation rules (i.e. `"upper"`, `"lower"`, or `"false"`)
+     * @param string | null $collation The locale's collation type
+     * @param string | null $hourCycle The locale's time-keeping convention
+     *     (i.e., `"h11"`, `"h12"`, `"h23"`, or `"h24"`)
+     * @param string | null $language The locale's language
+     * @param string | null $numberingSystem The locale's numeral system
+     * @param bool | null $numeric Whether the locale has special collation
+     *     handling for numeric strings
+     * @param string | null $region The locale's region
+     * @param string | null $script The locale's script used for writing
+     *
+     * @psalm-param "upper" | "lower" | "false" | null $caseFirst
+     * @psalm-param "h11" | "h12" | "h23" | "h24" | null $hourCycle
+     */
+    public function __construct(
+        ?string $calendar = null,
+        ?string $caseFirst = null,
+        ?string $collation = null,
+        ?string $hourCycle = null,
+        ?string $language = null,
+        ?string $numberingSystem = null,
+        ?bool $numeric = null,
+        ?string $region = null,
+        ?string $script = null
+    ) {
+        $this->numeric = $numeric;
+        $this->calendar = $calendar;
+        $this->caseFirst = $caseFirst;
+        $this->collation = $collation;
+        $this->hourCycle = $hourCycle;
+        $this->language = $language;
+        $this->numberingSystem = $numberingSystem;
+        $this->region = $region;
+        $this->script = $script;
+    }
+}

--- a/src/Intl/MessageFormat.php
+++ b/src/Intl/MessageFormat.php
@@ -62,7 +62,7 @@ class MessageFormat
     public function format(DescriptorInterface $descriptor, array $values = []): string
     {
         return (string) PhpMessageFormatter::formatMessage(
-            $this->config->getLocale()->getId(),
+            (string) $this->config->getLocale()->baseName(),
             $this->getMessage($descriptor),
             $values,
         );
@@ -114,7 +114,11 @@ class MessageFormat
             return $config->getMessages()->getMessage($messageId, $config->getLocale());
         } catch (MessageNotFoundException $exception) {
             try {
-                return $config->getMessages()->getMessage($messageId, $config->getLocale()->getFallbackLocale());
+                // Try falling back to a locale made up of just the language.
+                return $config->getMessages()->getMessage(
+                    $messageId,
+                    new Locale((string) $config->getLocale()->language()),
+                );
             } catch (MessageNotFoundException $exception) {
                 $defaultLocale = $config->getDefaultLocale();
                 if ($defaultLocale !== null) {

--- a/src/MessageCollection.php
+++ b/src/MessageCollection.php
@@ -58,7 +58,7 @@ final class MessageCollection extends AbstractCollection implements IteratorAggr
     private function findMessage(string $id, LocaleInterface $locale): MessageInterface
     {
         foreach ($this as $message) {
-            if ($message->getId() === $id && $message->getLocale()->getId() === $locale->getId()) {
+            if ($message->getId() === $id && $message->getLocale()->baseName() === $locale->baseName()) {
                 return $message;
             }
         }

--- a/tests/Intl/LocaleTest.php
+++ b/tests/Intl/LocaleTest.php
@@ -4,34 +4,210 @@ declare(strict_types=1);
 
 namespace FormatPHP\Test\Intl;
 
+use BadMethodCallException;
 use FormatPHP\Exception\InvalidArgumentException;
 use FormatPHP\Intl\Locale;
-use FormatPHP\Intl\LocaleInterface;
+use FormatPHP\Intl\LocaleOptions;
 use FormatPHP\Test\TestCase;
+use Locale as PhpLocale;
 
 class LocaleTest extends TestCase
 {
-    public function testGetId(): void
-    {
-        $locale = new Locale('pt-BR');
-
-        $this->assertSame('pt-BR', $locale->getId());
-    }
-
-    public function testGetFallbackLocale(): void
-    {
-        $locale = new Locale('pt-BR');
-        $fallbackLocale = $locale->getFallbackLocale();
-
-        $this->assertInstanceOf(LocaleInterface::class, $fallbackLocale);
-        $this->assertSame('pt', $fallbackLocale->getId());
-    }
-
     public function testExceptionWhenLocaleIsInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('f-oo-bar is not valid BCP 47 formatted locale string.');
+        $this->expectExceptionMessage('Unable to parse "f-oo-bar" as a valid locale string');
 
         new Locale('f-oo-bar');
+    }
+
+    public function testLocaleWithEverythingAsPartOfTheIdentifier(): void
+    {
+        $localeString = 'zh-cmn-Hans-CN-boont-u-kf-lower-co-trad-kn-false-ca-buddhist-nu-latn-hc-h24';
+
+        $locale = new Locale($localeString);
+
+        $this->assertSame('cmn-Hans-CN-BOONT', $locale->baseName());
+        $this->assertSame('cmn', $locale->language());
+        $this->assertSame('CN', $locale->region());
+        $this->assertSame('Hans', $locale->script());
+        $this->assertSame('trad', $locale->collation());
+        $this->assertSame('lower', $locale->caseFirst());
+        $this->assertFalse($locale->numeric());
+        $this->assertSame('buddhist', $locale->calendar());
+        $this->assertSame('latn', $locale->numberingSystem());
+        $this->assertSame('h24', $locale->hourCycle());
+        $this->assertSame(
+            'cmn-Hans-CN-BOONT-u-ca-buddhist-kf-lower-co-trad-kn-false-hc-h24-nu-latn',
+            $locale->toString(),
+        );
+    }
+
+    public function testLocaleWithEverythingAsPartOfTheOptions(): void
+    {
+        $locale = new Locale('en-latn-CA-boont', new LocaleOptions(
+            'buddhist',
+            'lower',
+            'emoji',
+            'h24',
+            'cmn',
+            'latn',
+            false,
+            'CN',
+            'Hans',
+        ));
+
+        $this->assertSame(
+            'cmn-Hans-CN-BOONT-u-ca-buddhist-kf-lower-co-emoji-hc-h24-nu-latn-kn-false',
+            $locale->toString(),
+        );
+    }
+
+    public function testLocaleWithEmptyLanguage(): void
+    {
+        $locale = new Locale(
+            'en-Latn-US-variant',
+            new LocaleOptions(null, null, null, null, ''),
+        );
+
+        $this->assertSame('', $locale->baseName());
+    }
+
+    public function testLocaleWithOnlyLanguage(): void
+    {
+        $locale = new Locale('en');
+
+        $this->assertSame('en', $locale->baseName());
+        $this->assertSame('en', $locale->language());
+        $this->assertNull($locale->region());
+        $this->assertNull($locale->script());
+        $this->assertNull($locale->collation());
+        $this->assertNull($locale->caseFirst());
+        $this->assertFalse($locale->numeric());
+        $this->assertNull($locale->calendar());
+        $this->assertNull($locale->numberingSystem());
+        $this->assertNull($locale->hourCycle());
+    }
+
+    public function testLocaleWithUndefinedLocale(): void
+    {
+        $defaultLocale = new Locale(PhpLocale::getDefault());
+        $undefinedLocale = new Locale('und');
+
+        $this->assertSame($defaultLocale->toString(), $undefinedLocale->toString());
+    }
+
+    public function testBaseNameWithMultipleVariants(): void
+    {
+        $locale = new Locale('en-US-variant1-variant2-variant3');
+
+        $this->assertSame('en-US-VARIANT1-VARIANT2-VARIANT3', $locale->baseName());
+    }
+
+    public function testCalendarReturnsEthioaa(): void
+    {
+        $locale = new Locale('en-US@calendar=ethiopic-amete-alem');
+
+        $this->assertSame('ethioaa', $locale->calendar());
+        $this->assertSame('en-US-u-ca-ethioaa', $locale->toString());
+    }
+
+    public function testCalendarReturnsGregory(): void
+    {
+        $locale = new Locale('en-US@calendar=gregorian');
+
+        $this->assertSame('gregory', $locale->calendar());
+        $this->assertSame('en-US-u-ca-gregory', $locale->toString());
+    }
+
+    public function testCaseFirstReturnsStringFalse(): void
+    {
+        $locale = new Locale('en-US@colcasefirst=no');
+
+        $this->assertSame('false', $locale->caseFirst());
+        $this->assertSame('en-US-u-kf-false', $locale->toString());
+    }
+
+    public function testCollationReturnsDict(): void
+    {
+        $locale = new Locale('en-US@collation=dictionary');
+
+        $this->assertSame('dict', $locale->collation());
+        $this->assertSame('en-US-u-co-dict', $locale->toString());
+    }
+
+    public function testCollationReturnsGb2312(): void
+    {
+        $locale = new Locale('en-US@collation=gb2312han');
+
+        $this->assertSame('gb2312', $locale->collation());
+        $this->assertSame('en-US-u-co-gb2312', $locale->toString());
+    }
+
+    public function testCollationReturnsPhonebk(): void
+    {
+        $locale = new Locale('en-US@collation=phonebook');
+
+        $this->assertSame('phonebk', $locale->collation());
+        $this->assertSame('en-US-u-co-phonebk', $locale->toString());
+    }
+
+    public function testCollationReturnsTraditio(): void
+    {
+        $locale = new Locale('en-US@numbers=traditional');
+
+        $this->assertSame('traditio', $locale->numberingSystem());
+        $this->assertSame('en-US-u-nu-traditio', $locale->toString());
+    }
+
+    public function testNumericWithYes(): void
+    {
+        $locale = new Locale('en-US@colnumeric=yes');
+
+        $this->assertTrue($locale->numeric());
+        $this->assertSame('en-US-u-kn-true', $locale->toString());
+    }
+
+    public function testNumericWithNo(): void
+    {
+        $locale = new Locale('en-US@colnumeric=no');
+
+        $this->assertFalse($locale->numeric());
+        $this->assertSame('en-US-u-kn-false', $locale->toString());
+    }
+
+    public function testNumericWithInvalidValue(): void
+    {
+        $locale = new Locale('en-US@colnumeric=foo');
+
+        $this->assertFalse($locale->numeric());
+        $this->assertSame('en-US', $locale->toString());
+    }
+
+    public function testPassesThroughUnknownKeyword(): void
+    {
+        $locale = new Locale('en-US-u-ka-noignore');
+
+        $this->assertSame('en-US-u-colalternate-non-ignorable', $locale->toString());
+    }
+
+    public function testMaximizeThrowsException(): void
+    {
+        $locale = new Locale('en-US');
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Method not implemented');
+
+        $locale->maximize();
+    }
+
+    public function testMinimizeThrowsException(): void
+    {
+        $locale = new Locale('en-US');
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Method not implemented');
+
+        $locale->minimize();
     }
 }

--- a/tests/Intl/LocaleTest.php
+++ b/tests/Intl/LocaleTest.php
@@ -181,7 +181,7 @@ class LocaleTest extends TestCase
         $locale = new Locale('en-US@colnumeric=foo');
 
         $this->assertFalse($locale->numeric());
-        $this->assertSame('en-US', $locale->toString());
+        $this->assertSame('en-US-u-kn-foo', $locale->toString());
     }
 
     public function testPassesThroughUnknownKeyword(): void

--- a/tests/MessageCollectionTest.php
+++ b/tests/MessageCollectionTest.php
@@ -21,13 +21,13 @@ class MessageCollectionTest extends TestCase
     public function testGetMessageFindsAndReturnsMessage(): void
     {
         $locale = $this->mockery(LocaleInterface::class, [
-            'getId' => 'en-US',
+            'baseName' => 'en-US',
         ]);
 
         $message = $this->mockery(MessageInterface::class, [
             'getId' => 'foobar',
             'getLocale' => $this->mockery(LocaleInterface::class, [
-                'getId' => 'en-US',
+                'baseName' => 'en-US',
             ]),
             'getMessage' => 'This is a message',
         ]);
@@ -43,7 +43,7 @@ class MessageCollectionTest extends TestCase
     public function testGetMessageThrowsExceptionWhenMessageNotFound(): void
     {
         $locale = $this->mockery(LocaleInterface::class, [
-            'getId' => 'en-US',
+            'baseName' => 'en-US',
         ]);
 
         $collection = new MessageCollection();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

This PR improves `Intl.Locale` parity with FormatJS and ECMA-402:

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale
* https://formatjs.io/docs/polyfills/intl-locale
* https://tc39.es/ecma402/#locale-objects

Future improvements to bring this into closer parity might include porting the test262 test suite to PHP in order to ensure full compliance with ECMA-402: https://github.com/tc39/test262/tree/master/test/intl402/Locale

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We desire to create a library that has feature parity with FormatJS and conforms to the familiar ECMAScript 402 specification.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
