### PR TITLE
refactor: move readers and writers under common Format namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/php:8.0
+      - image: cimg/php:7.4
 
     steps:
       - checkout
       - run: |
           sudo apt update
-          sudo apt install php-intl php-pcov
+          sudo apt install php7.4-intl php7.4-pcov
 
       # Install Composer dependencies.
       - restore_cache:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "nikic/php-parser": "^4.13",
-        "psr/log": "^2",
+        "psr/log": "^1 || ^2",
         "ramsey/collection": "^1.2",
         "symfony/console": "^5.3",
         "symfony/polyfill-php80": "^1.23",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,9 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+
+        <!-- Ignore this for PHP 7.4 -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
     </rule>
 
 </ruleset>

--- a/src/Console/Command/ExtractCommand.php
+++ b/src/Console/Command/ExtractCommand.php
@@ -212,9 +212,12 @@ class ExtractCommand extends AbstractCommand
         $options->extractSourceLocation = (bool) $input->getOption('extract-source-location');
         $options->throws = (bool) $input->getOption('throws');
         $options->preserveWhitespace = (bool) $input->getOption('preserve-whitespace');
+
+        /** @var string $additionalFunctionNames */
+        $additionalFunctionNames = $input->getOption('additional-function-names') ?? '';
         $options->additionalFunctionNames = array_merge(
             self::DEFAULT_FUNCTION_NAMES,
-            array_map('trim', explode(',', (string) $input->getOption('additional-function-names'))),
+            array_map('trim', explode(',', $additionalFunctionNames)),
         );
 
         return $options;

--- a/src/DescriptorInterface.php
+++ b/src/DescriptorInterface.php
@@ -57,7 +57,7 @@ interface DescriptorInterface
     /**
      * Returns an array representation of the descriptor
      *
-     * @return array<string, string | int | array | null>
+     * @return array<string, string | int | mixed[] | null>
      */
     public function toArray(): array;
 }

--- a/src/Exception/InvalidMessageShapeException.php
+++ b/src/Exception/InvalidMessageShapeException.php
@@ -22,13 +22,13 @@ declare(strict_types=1);
 
 namespace FormatPHP\Exception;
 
-use FormatPHP\Reader\FormatInterface;
+use FormatPHP\Format\ReaderInterface;
 use RuntimeException as PhpRuntimeException;
 
 /**
  * Thrown when reading a message that doesn't conform to the expected shape
  *
- * @see FormatInterface
+ * @see ReaderInterface
  */
 class InvalidMessageShapeException extends PhpRuntimeException implements FormatPHPExceptionInterface
 {

--- a/src/Extractor/MessageExtractor.php
+++ b/src/Extractor/MessageExtractor.php
@@ -31,12 +31,12 @@ use FormatPHP\Exception\UnableToProcessFileException;
 use FormatPHP\Exception\UnableToWriteFileException;
 use FormatPHP\Extractor\Parser\Descriptor\PhpParser;
 use FormatPHP\Extractor\Parser\DescriptorParserInterface;
+use FormatPHP\Format\Writer\FormatPHPWriter;
+use FormatPHP\Format\Writer\SimpleWriter;
+use FormatPHP\Format\Writer\SmartlingWriter;
+use FormatPHP\Format\WriterInterface;
 use FormatPHP\Util\FileSystemHelper;
 use FormatPHP\Util\Globber;
-use FormatPHP\Writer\Format\FormatPHP;
-use FormatPHP\Writer\Format\Simple;
-use FormatPHP\Writer\Format\Smartling;
-use FormatPHP\Writer\FormatInterface;
 use LogicException;
 use Psr\Log\LoggerInterface;
 
@@ -183,20 +183,20 @@ class MessageExtractor
     private function getFormatter(?string $format): callable
     {
         if ($format === null) {
-            return new FormatPHP();
+            return new FormatPHPWriter();
         }
 
         switch (strtolower($format)) {
             case 'simple':
-                return new Simple();
+                return new SimpleWriter();
             case 'smartling':
-                return new Smartling();
+                return new SmartlingWriter();
             case 'formatjs':
             case 'formatphp':
-                return new FormatPHP();
+                return new FormatPHPWriter();
         }
 
-        if (class_exists($format) && is_a($format, FormatInterface::class, true)) {
+        if (class_exists($format) && is_a($format, WriterInterface::class, true)) {
             $formatter = new $format();
         } else {
             /** @var Closure(DescriptorCollection,MessageExtractorOptions):array<mixed> | null $formatter */
@@ -210,7 +210,7 @@ class MessageExtractor
         throw new InvalidArgumentException(sprintf(
             'The format provided is not a known format, an instance of '
             . '%s, or a callable of the shape `callable(%s,%s):array<mixed>`.',
-            FormatInterface::class,
+            WriterInterface::class,
             DescriptorCollection::class,
             MessageExtractorOptions::class,
         ));

--- a/src/Format/Reader/FormatPHPReader.php
+++ b/src/Format/Reader/FormatPHPReader.php
@@ -68,8 +68,6 @@ class FormatPHPReader implements ReaderInterface
      * @param mixed $message
      *
      * @throws InvalidMessageShapeException
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     private function validateShape($messageId, $message): void
     {

--- a/src/Format/Reader/SimpleReader.php
+++ b/src/Format/Reader/SimpleReader.php
@@ -66,8 +66,6 @@ class SimpleReader implements ReaderInterface
      * @param mixed $message
      *
      * @throws InvalidMessageShapeException
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     private function validateShape($messageId, $message): void
     {

--- a/src/Format/Reader/SimpleReader.php
+++ b/src/Format/Reader/SimpleReader.php
@@ -20,28 +20,28 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Reader\Format;
+namespace FormatPHP\Format\Reader;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
+use FormatPHP\Format\ReaderInterface;
+use FormatPHP\Format\Writer\SimpleWriter;
 use FormatPHP\Intl\LocaleInterface;
 use FormatPHP\Message;
 use FormatPHP\MessageCollection;
-use FormatPHP\Reader\FormatInterface;
 
 use function assert;
 use function gettype;
-use function is_array;
 use function is_string;
 use function sprintf;
 
 /**
  * Returns a MessageCollection parsed from JSON-decoded data that was written
- * using Writer\Format\FormatPHP
+ * using Writer\Format\Simple
  *
- * @see \FormatPHP\Writer\Format\FormatPHP
+ * @see SimpleWriter
  */
-class FormatPHP implements FormatInterface
+class SimpleReader implements ReaderInterface
 {
     /**
      * @inheritdoc
@@ -53,10 +53,9 @@ class FormatPHP implements FormatInterface
         foreach ($data as $messageId => $message) {
             $this->validateShape($messageId, $message);
             assert(is_string($messageId));
-            assert(isset($message['defaultMessage']));
-            assert(is_string($message['defaultMessage']));
+            assert(is_string($message));
 
-            $messages[] = new Message($localeResolved, $messageId, $message['defaultMessage']);
+            $messages[$messageId] = new Message($localeResolved, $messageId, $message);
         }
 
         return $messages;
@@ -80,10 +79,11 @@ class FormatPHP implements FormatInterface
             ));
         }
 
-        if (!is_array($message) || !is_string($message['defaultMessage'] ?? null)) {
+        if (!is_string($message)) {
             throw new InvalidMessageShapeException(sprintf(
-                '%s expects a string defaultMessage property; defaultMessage does not exist or is not a string',
+                '%s expects a string message; received %s',
                 self::class,
+                gettype($message),
             ));
         }
     }

--- a/src/Format/Reader/SmartlingReader.php
+++ b/src/Format/Reader/SmartlingReader.php
@@ -70,8 +70,6 @@ class SmartlingReader implements ReaderInterface
      * @param mixed $message
      *
      * @throws InvalidMessageShapeException
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     private function validateShape($messageId, $message): void
     {

--- a/src/Format/Reader/SmartlingReader.php
+++ b/src/Format/Reader/SmartlingReader.php
@@ -20,16 +20,16 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Reader\Format;
+namespace FormatPHP\Format\Reader;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
+use FormatPHP\Format\ReaderInterface;
+use FormatPHP\Format\Writer\SmartlingWriter;
 use FormatPHP\Intl\LocaleInterface;
 use FormatPHP\Message;
 use FormatPHP\MessageCollection;
-use FormatPHP\Reader\FormatInterface;
 
-use function assert;
 use function gettype;
 use function is_array;
 use function is_string;
@@ -39,9 +39,9 @@ use function sprintf;
  * Returns a MessageCollection parsed from JSON-decoded data that was written
  * using Writer\Format\Smartling
  *
- * @see \FormatPHP\Writer\Format\Smartling
+ * @see SmartlingWriter
  */
-class Smartling implements FormatInterface
+class SmartlingReader implements ReaderInterface
 {
     /**
      * @inheritdoc
@@ -52,11 +52,12 @@ class Smartling implements FormatInterface
 
         unset($data['smartling']);
 
+        /**
+         * @var string $messageId
+         * @var array{message: string} $message
+         */
         foreach ($data as $messageId => $message) {
             $this->validateShape($messageId, $message);
-            assert(is_string($messageId));
-            assert(isset($message['message']));
-            assert(is_string($message['message']));
 
             $messages[] = new Message($localeResolved, $messageId, $message['message']);
         }

--- a/src/Format/ReaderInterface.php
+++ b/src/Format/ReaderInterface.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Reader;
+namespace FormatPHP\Format;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
@@ -30,7 +30,7 @@ use FormatPHP\MessageCollection;
 /**
  * Returns a collection of messages parsed from JSON-decoded message data
  */
-interface FormatInterface
+interface ReaderInterface
 {
     /**
      * @param array<array-key, mixed> $data An arbitrary array of JSON-decoded

--- a/src/Format/Writer/FormatPHPWriter.php
+++ b/src/Format/Writer/FormatPHPWriter.php
@@ -20,12 +20,13 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Writer\Format;
+namespace FormatPHP\Format\Writer;
 
 use FormatPHP\DescriptorCollection;
 use FormatPHP\ExtendedDescriptorInterface;
 use FormatPHP\Extractor\MessageExtractorOptions;
-use FormatPHP\Writer\FormatInterface;
+use FormatPHP\Format\Reader\FormatPHPReader;
+use FormatPHP\Format\WriterInterface;
 
 use function array_merge;
 use function ksort;
@@ -56,8 +57,9 @@ use function ksort;
  * pairs, according to the pragma parsed from each source file.
  *
  * @link https://formatjs.io/docs/getting-started/message-extraction FormatJS message extraction
+ * @see FormatPHPReader
  */
-class FormatPHP implements FormatInterface
+class FormatPHPWriter implements WriterInterface
 {
     /**
      * @inheritdoc

--- a/src/Format/Writer/SimpleWriter.php
+++ b/src/Format/Writer/SimpleWriter.php
@@ -20,11 +20,12 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Writer\Format;
+namespace FormatPHP\Format\Writer;
 
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
-use FormatPHP\Writer\FormatInterface;
+use FormatPHP\Format\Reader\SimpleReader;
+use FormatPHP\Format\WriterInterface;
 
 /**
  * A simple formatter for FormatPHP, producing message key-value pairs
@@ -36,8 +37,10 @@ use FormatPHP\Writer\FormatInterface;
  *   "my.message": "This is a message for translation."
  * }
  * ```
+ *
+ * @see SimpleReader
  */
-class Simple implements FormatInterface
+class SimpleWriter implements WriterInterface
 {
     /**
      * @inheritdoc

--- a/src/Format/Writer/SmartlingWriter.php
+++ b/src/Format/Writer/SmartlingWriter.php
@@ -20,11 +20,12 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Writer\Format;
+namespace FormatPHP\Format\Writer;
 
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
-use FormatPHP\Writer\FormatInterface;
+use FormatPHP\Format\Reader\SmartlingReader;
+use FormatPHP\Format\WriterInterface;
 
 /**
  * Smartling formatter for FormatPHP
@@ -53,8 +54,9 @@ use FormatPHP\Writer\FormatInterface;
  * ```
  *
  * @link https://help.smartling.com/hc/en-us/articles/360008000733 Smartling JSON Format
+ * @see SmartlingReader
  */
-class Smartling implements FormatInterface
+class SmartlingWriter implements WriterInterface
 {
     /**
      * @inheritdoc

--- a/src/Format/WriterInterface.php
+++ b/src/Format/WriterInterface.php
@@ -20,12 +20,12 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Writer;
+namespace FormatPHP\Format;
 
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
 
-interface FormatInterface
+interface WriterInterface
 {
     /**
      * @return mixed[]

--- a/src/FormatPHP.php
+++ b/src/FormatPHP.php
@@ -29,7 +29,6 @@ use FormatPHP\Intl\MessageFormat;
  */
 class FormatPHP implements FormatterInterface
 {
-    private ConfigInterface $config;
     private MessageCollection $messages;
     private MessageFormat $messageFormat;
 
@@ -40,7 +39,6 @@ class FormatPHP implements FormatterInterface
         ConfigInterface $config,
         MessageCollection $messages
     ) {
-        $this->config = $config;
         $this->messages = $messages;
         $this->messageFormat = new MessageFormat($config->getLocale());
     }

--- a/src/Intl/MessageFormat.php
+++ b/src/Intl/MessageFormat.php
@@ -28,6 +28,7 @@ use IntlException as PhpIntlException;
 use Locale as PhpLocale;
 use MessageFormatter as PhpMessageFormatter;
 
+use function is_int;
 use function sprintf;
 
 /**
@@ -61,7 +62,7 @@ class MessageFormat implements MessageFormatInterface
                     $pattern,
                     (string) $this->locale->baseName(),
                 ),
-                (int) $exception->getCode(),
+                is_int($exception->getCode()) ? $exception->getCode() : 0,
                 $exception,
             );
         }

--- a/src/MessageLoader.php
+++ b/src/MessageLoader.php
@@ -26,9 +26,9 @@ use FormatPHP\Exception\InvalidArgumentException;
 use FormatPHP\Exception\InvalidMessageShapeException;
 use FormatPHP\Exception\LocaleNotFoundException;
 use FormatPHP\Exception\UnableToProcessFileException;
+use FormatPHP\Format\ReaderInterface;
 use FormatPHP\Intl\Locale;
 use FormatPHP\Intl\LocaleInterface;
-use FormatPHP\Reader\FormatInterface;
 use FormatPHP\Util\FileSystemHelper;
 
 use function array_filter;
@@ -46,7 +46,7 @@ final class MessageLoader
 {
     private Config $config;
     private FileSystemHelper $fileSystemHelper;
-    private FormatInterface $formatReader;
+    private ReaderInterface $formatReader;
     private string $messagesDirectory;
 
     /**
@@ -55,7 +55,7 @@ final class MessageLoader
     public function __construct(
         string $messagesDirectory,
         Config $config,
-        FormatInterface $formatReader,
+        ReaderInterface $formatReader,
         ?FileSystemHelper $fileSystemHelper = null
     ) {
         $this->config = $config;

--- a/src/Util/FileSystemHelper.php
+++ b/src/Util/FileSystemHelper.php
@@ -37,6 +37,7 @@ use function getcwd;
 use function gettype;
 use function is_callable;
 use function is_dir;
+use function is_int;
 use function is_readable;
 use function is_resource;
 use function is_string;
@@ -96,12 +97,14 @@ class FileSystemHelper
         $contents = $this->getContents($filePath);
 
         try {
-            /** @var array<array-key, mixed> */
-            return @json_decode($contents, true, 512, self::JSON_DECODE_FLAGS);
+            /** @var array<array-key, mixed> $parsedContents */
+            $parsedContents = @json_decode($contents, true, 512, self::JSON_DECODE_FLAGS);
+
+            return $parsedContents;
         } catch (JsonException $exception) {
             throw new UnableToProcessFileException(
                 sprintf('Unable to decode the JSON in the file "%s"', $filePath),
-                (int) $exception->getCode(),
+                is_int($exception->getCode()) ? $exception->getCode() : 0,
                 $exception,
             );
         }

--- a/tests/Extractor/CustomFormat.php
+++ b/tests/Extractor/CustomFormat.php
@@ -6,9 +6,9 @@ namespace FormatPHP\Test\Extractor;
 
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
-use FormatPHP\Writer\FormatInterface;
+use FormatPHP\Format\WriterInterface;
 
-class CustomFormat implements FormatInterface
+class CustomFormat implements WriterInterface
 {
     /**
      * @inheritdoc

--- a/tests/Extractor/MessageExtractorTest.php
+++ b/tests/Extractor/MessageExtractorTest.php
@@ -277,7 +277,7 @@ class MessageExtractorTest extends TestCase
         $logger = $this->mockery(LoggerInterface::class);
         $logger->shouldReceive('error')->withArgs(function (string $message): bool {
             $expected = 'The format provided is not a known format, an instance of '
-            . 'FormatPHP\\Writer\\FormatInterface, or a callable of the '
+            . 'FormatPHP\\Format\\WriterInterface, or a callable of the '
             . 'shape `callable(FormatPHP\\DescriptorCollection,'
             . 'FormatPHP\\Extractor\\MessageExtractorOptions):array<mixed>`.';
 

--- a/tests/Format/Reader/FormatPHPReaderTest.php
+++ b/tests/Format/Reader/FormatPHPReaderTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Reader\Format;
+namespace FormatPHP\Test\Format\Reader;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
+use FormatPHP\Format\Reader\FormatPHPReader;
 use FormatPHP\Intl\Locale;
 use FormatPHP\MessageCollection;
 use FormatPHP\MessageInterface;
-use FormatPHP\Reader\Format\Simple;
 use FormatPHP\Test\TestCase;
 
 use function sprintf;
 
-class SimpleTest extends TestCase
+class FormatPHPReaderTest extends TestCase
 {
     public function testThrowsExceptionWhenMessageIdIsNotAString(): void
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Simple();
+        $formatReader = new FormatPHPReader();
         $data = ['foo'];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
             '%s expects a string message ID; received integer',
-            Simple::class,
+            FormatPHPReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -36,13 +36,13 @@ class SimpleTest extends TestCase
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Simple();
+        $formatReader = new FormatPHPReader();
         $data = ['foo' => ['bar']];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
-            '%s expects a string message; received array',
-            Simple::class,
+            '%s expects a string defaultMessage property; defaultMessage does not exist or is not a string',
+            FormatPHPReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -53,8 +53,8 @@ class SimpleTest extends TestCase
         $locale = new Locale('en-US');
         $localeResolved = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Simple();
-        $data = ['foo' => 'I am foo', 'bar' => 'I am bar'];
+        $formatReader = new FormatPHPReader();
+        $data = ['foo' => ['defaultMessage' => 'I am foo'], 'bar' => ['defaultMessage' => 'I am bar']];
 
         $collection = $formatReader($config, $data, $localeResolved);
 

--- a/tests/Format/Reader/SimpleReaderTest.php
+++ b/tests/Format/Reader/SimpleReaderTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Reader\Format;
+namespace FormatPHP\Test\Format\Reader;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
+use FormatPHP\Format\Reader\SimpleReader;
 use FormatPHP\Intl\Locale;
 use FormatPHP\MessageCollection;
 use FormatPHP\MessageInterface;
-use FormatPHP\Reader\Format\Smartling;
 use FormatPHP\Test\TestCase;
 
 use function sprintf;
 
-class SmartlingTest extends TestCase
+class SimpleReaderTest extends TestCase
 {
     public function testThrowsExceptionWhenMessageIdIsNotAString(): void
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Smartling();
-        $data = ['smartling' => [], 'foo'];
+        $formatReader = new SimpleReader();
+        $data = ['foo'];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
             '%s expects a string message ID; received integer',
-            Smartling::class,
+            SimpleReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -36,13 +36,13 @@ class SmartlingTest extends TestCase
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Smartling();
-        $data = ['smartling' => [], 'foo' => ['bar']];
+        $formatReader = new SimpleReader();
+        $data = ['foo' => ['bar']];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
-            '%s expects a string message property; message does not exist or is not a string',
-            Smartling::class,
+            '%s expects a string message; received array',
+            SimpleReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -53,8 +53,8 @@ class SmartlingTest extends TestCase
         $locale = new Locale('en-US');
         $localeResolved = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new Smartling();
-        $data = ['smartling' => [], 'foo' => ['message' => 'I am foo'], 'bar' => ['message' => 'I am bar']];
+        $formatReader = new SimpleReader();
+        $data = ['foo' => 'I am foo', 'bar' => 'I am bar'];
 
         $collection = $formatReader($config, $data, $localeResolved);
 

--- a/tests/Format/Reader/SmartlingReaderTest.php
+++ b/tests/Format/Reader/SmartlingReaderTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Reader\Format;
+namespace FormatPHP\Test\Format\Reader;
 
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidMessageShapeException;
+use FormatPHP\Format\Reader\SmartlingReader;
 use FormatPHP\Intl\Locale;
 use FormatPHP\MessageCollection;
 use FormatPHP\MessageInterface;
-use FormatPHP\Reader\Format\FormatPHP;
 use FormatPHP\Test\TestCase;
 
 use function sprintf;
 
-class FormatPHPTest extends TestCase
+class SmartlingReaderTest extends TestCase
 {
     public function testThrowsExceptionWhenMessageIdIsNotAString(): void
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new FormatPHP();
-        $data = ['foo'];
+        $formatReader = new SmartlingReader();
+        $data = ['smartling' => [], 'foo'];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
             '%s expects a string message ID; received integer',
-            FormatPHP::class,
+            SmartlingReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -36,13 +36,13 @@ class FormatPHPTest extends TestCase
     {
         $locale = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new FormatPHP();
-        $data = ['foo' => ['bar']];
+        $formatReader = new SmartlingReader();
+        $data = ['smartling' => [], 'foo' => ['bar']];
 
         $this->expectException(InvalidMessageShapeException::class);
         $this->expectExceptionMessage(sprintf(
-            '%s expects a string defaultMessage property; defaultMessage does not exist or is not a string',
-            FormatPHP::class,
+            '%s expects a string message property; message does not exist or is not a string',
+            SmartlingReader::class,
         ));
 
         $formatReader($config, $data, $locale);
@@ -53,8 +53,8 @@ class FormatPHPTest extends TestCase
         $locale = new Locale('en-US');
         $localeResolved = new Locale('en');
         $config = new Config($locale);
-        $formatReader = new FormatPHP();
-        $data = ['foo' => ['defaultMessage' => 'I am foo'], 'bar' => ['defaultMessage' => 'I am bar']];
+        $formatReader = new SmartlingReader();
+        $data = ['smartling' => [], 'foo' => ['message' => 'I am foo'], 'bar' => ['message' => 'I am bar']];
 
         $collection = $formatReader($config, $data, $localeResolved);
 

--- a/tests/Format/Writer/FormatPHPWriterTest.php
+++ b/tests/Format/Writer/FormatPHPWriterTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Writer\Format;
+namespace FormatPHP\Test\Format\Writer;
 
 use FormatPHP\Descriptor;
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Format\Writer\FormatPHPWriter;
 use FormatPHP\Test\TestCase;
-use FormatPHP\Writer\Format\FormatPHP;
 
-class FormatPHPTest extends TestCase
+class FormatPHPWriterTest extends TestCase
 {
     public function testFormatterBasic(): void
     {
@@ -21,7 +21,7 @@ class FormatPHPTest extends TestCase
         $collection->add(new Descriptor('bar', 'some message'));
         $collection->add(new Descriptor('baz', 'another message', 'a description'));
 
-        $formatter = new FormatPHP();
+        $formatter = new FormatPHPWriter();
 
         $this->assertSame(
             [
@@ -57,7 +57,7 @@ class FormatPHPTest extends TestCase
         $collection = new DescriptorCollection();
         $collection->add($descriptor);
 
-        $formatter = new FormatPHP();
+        $formatter = new FormatPHPWriter();
 
         $this->assertSame(
             [

--- a/tests/Format/Writer/SimpleWriterTest.php
+++ b/tests/Format/Writer/SimpleWriterTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Writer\Format;
+namespace FormatPHP\Test\Format\Writer;
 
 use FormatPHP\Descriptor;
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Format\Writer\SimpleWriter;
 use FormatPHP\Test\TestCase;
-use FormatPHP\Writer\Format\Simple;
 
-class SimpleTest extends TestCase
+class SimpleWriterTest extends TestCase
 {
     public function testInvoke(): void
     {
@@ -23,7 +23,7 @@ class SimpleTest extends TestCase
                 'aaa' => 'first message',
                 'bbb' => 'second message',
             ],
-            (new Simple())($collection, new MessageExtractorOptions()),
+            (new SimpleWriter())($collection, new MessageExtractorOptions()),
         );
     }
 }

--- a/tests/Format/Writer/SmartlingWriterTest.php
+++ b/tests/Format/Writer/SmartlingWriterTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace FormatPHP\Test\Writer\Format;
+namespace FormatPHP\Test\Format\Writer;
 
 use FormatPHP\Descriptor;
 use FormatPHP\DescriptorCollection;
 use FormatPHP\Extractor\MessageExtractorOptions;
+use FormatPHP\Format\Writer\SmartlingWriter;
 use FormatPHP\Test\TestCase;
-use FormatPHP\Writer\Format\Smartling;
 
-class SmartlingTest extends TestCase
+class SmartlingWriterTest extends TestCase
 {
     public function testFormatter(): void
     {
@@ -21,7 +21,7 @@ class SmartlingTest extends TestCase
         $collection->add(new Descriptor('bar', 'some message'));
         $collection->add(new Descriptor('baz', 'another message', 'a description'));
 
-        $formatter = new Smartling();
+        $formatter = new SmartlingWriter();
 
         $this->assertSame(
             [

--- a/tests/MessageLoaderTest.php
+++ b/tests/MessageLoaderTest.php
@@ -7,11 +7,11 @@ namespace FormatPHP\Test;
 use FormatPHP\Config;
 use FormatPHP\Exception\InvalidArgumentException;
 use FormatPHP\Exception\LocaleNotFoundException;
+use FormatPHP\Format\Reader\FormatPHPReader;
+use FormatPHP\Format\ReaderInterface;
 use FormatPHP\Intl\Locale;
 use FormatPHP\MessageInterface;
 use FormatPHP\MessageLoader;
-use FormatPHP\Reader\Format\FormatPHP;
-use FormatPHP\Reader\FormatInterface;
 
 use function sprintf;
 
@@ -28,7 +28,7 @@ class MessageLoaderTest extends TestCase
         new MessageLoader(
             __FILE__,
             new Config(new Locale('en')),
-            $this->mockery(FormatInterface::class),
+            $this->mockery(ReaderInterface::class),
         );
     }
 
@@ -40,7 +40,7 @@ class MessageLoaderTest extends TestCase
         $loader = new MessageLoader(
             __DIR__ . '/fixtures/locales',
             new Config($locale),
-            $this->mockery(FormatInterface::class),
+            $this->mockery(ReaderInterface::class),
         );
 
         $this->expectException(LocaleNotFoundException::class);
@@ -59,7 +59,7 @@ class MessageLoaderTest extends TestCase
         $loader = new MessageLoader(
             __DIR__ . '/fixtures/locales',
             new Config($locale, $defaultLocale),
-            new FormatPHP(),
+            new FormatPHPReader(),
         );
 
         $collection = $loader->loadMessages();
@@ -79,7 +79,7 @@ class MessageLoaderTest extends TestCase
         $loader = new MessageLoader(
             __DIR__ . '/fixtures/locales',
             new Config($locale, $defaultLocale),
-            new FormatPHP(),
+            new FormatPHPReader(),
         );
 
         $collection = $loader->loadMessages();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR does not introduce any changes to functionality. It moves readers and writers under a common `Format` namespace.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Clean up and simplify library API

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
