### PR TITLE
fix: parse only string literals

### DIFF
--- a/tests/Extractor/MessageExtractorTest.php
+++ b/tests/Extractor/MessageExtractorTest.php
@@ -424,6 +424,12 @@ class MessageExtractorTest extends TestCase
                 . '/Parser/Descriptor/fixtures/php-parser-04.php on line 40',
             'Descriptor argument must be present in ' . __DIR__
                 . '/Parser/Descriptor/fixtures/php-parser-09.phtml on line 18',
+            'The descriptor must not contain values other than string literals; '
+                . 'encountered Expr_Variable in ' . __DIR__
+                . '/Parser/Descriptor/fixtures/php-parser-10.php on line 6',
+            'The descriptor must not contain values other than string literals; '
+                . 'encountered Scalar_Encapsed in ' . __DIR__
+                . '/Parser/Descriptor/fixtures/php-parser-10.php on line 12',
             'Missing "defaultMessage" in "{{#formatMessage |idWithoutMessage}}{{/formatMessage}}" in '
                 . __DIR__ . '/Parser/Descriptor/fixtures/custom-parser-01.template on line 0',
             'Missing "id" in "{{#formatMessage}}message without ID{{/formatMessage}}" in '
@@ -499,6 +505,12 @@ class MessageExtractorTest extends TestCase
             . '/Parser/Descriptor/fixtures/php-parser-04.php on line 40',
             'Descriptor argument must be present in ' . __DIR__
             . '/Parser/Descriptor/fixtures/php-parser-09.phtml on line 18',
+            'The descriptor must not contain values other than string literals; '
+            . 'encountered Expr_Variable in ' . __DIR__
+            . '/Parser/Descriptor/fixtures/php-parser-10.php on line 6',
+            'The descriptor must not contain values other than string literals; '
+            . 'encountered Scalar_Encapsed in ' . __DIR__
+            . '/Parser/Descriptor/fixtures/php-parser-10.php on line 12',
             'Missing "defaultMessage" in "{{#formatMessage |idWithoutMessage}}{{/formatMessage}}" in '
             . __DIR__ . '/Parser/Descriptor/fixtures/custom-parser-01.template on line 0',
             'Missing "id" in "{{#formatMessage}}message without ID{{/formatMessage}}" in '

--- a/tests/Extractor/Parser/Descriptor/PhpParserTest.php
+++ b/tests/Extractor/Parser/Descriptor/PhpParserTest.php
@@ -31,7 +31,7 @@ class PhpParserTest extends TestCase
             [
                 'defaultMessage' => 'This is a default message',
                 'description' => 'A simple description of a fixture for testing purposes.',
-                'end' => 202,
+                'end' => 326,
                 'file' => __DIR__ . '/fixtures/php-parser-01.php',
                 'id' => 'aTestId',
                 'line' => 3,
@@ -318,6 +318,29 @@ class PhpParserTest extends TestCase
         $this->assertSame(
             [
                 'Descriptor argument must be present on line 18 in ' . __DIR__ . '/fixtures/php-parser-09.phtml',
+            ],
+            $receivedErrors,
+        );
+    }
+
+    public function testParse10(): void
+    {
+        $errors = new ParserErrorCollection();
+        $options = new MessageExtractorOptions();
+        $parser = new PhpParser(new FileSystemHelper());
+        $descriptors = $parser(__DIR__ . '/fixtures/php-parser-10.php', $options, $errors);
+        $receivedErrors = $this->compileErrors($errors);
+
+        $this->assertContainsOnlyInstancesOf(DescriptorInterface::class, $descriptors);
+        $this->assertCount(0, $descriptors);
+        $this->assertSame(
+            [
+                'The descriptor must not contain values other than string literals; '
+                    . 'encountered Expr_Variable on line 6 in '
+                    . __DIR__ . '/fixtures/php-parser-10.php',
+                'The descriptor must not contain values other than string literals; '
+                    . 'encountered Scalar_Encapsed on line 12 in '
+                    . __DIR__ . '/fixtures/php-parser-10.php',
             ],
             $receivedErrors,
         );

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-01.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-01.php
@@ -2,6 +2,9 @@
 
 $internationalization->formatMessage([
     'id' => 'aTestId',
-    'defaultMessage' => 'This is a default message',
-    'description' => 'A simple description of a fixture for testing purposes.',
+    // We're using concatenated string literals on purpose, to test this functionality.
+    'defaultMessage' => 'This is a ' . 'default ' . 'message',
+    'description' => 'A simple description '
+        . 'of a fixture '
+        . 'for testing purposes.',
 ]);

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-10.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-10.php
@@ -1,0 +1,17 @@
+<?php
+
+$bar = 'default ';
+$description = 'description';
+
+$internationalization->formatMessage([
+    'id' => 'message.with.variable.concat',
+    // Injecting a variable here to break things.
+    'defaultMessage' => 'This is a ' . $bar . 'message',
+]);
+
+$internationalization->formatMessage([
+    'id' => 'message.with.variable.interpolated',
+    // Injecting a variable here to break things.
+    'defaultMessage' => 'This is a default message',
+    'description' => "This is a $description with an interpolated variable.",
+]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR fixes two things:

1. It allows string literals in descriptors to be broken up with string concatenation (so we can break them over multiple lines)
2. It fails to parse descriptors that have anything other than string literals or concatenated string literals

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
