### PR TITLE
fix: accept any callable of the correct shape as a format reader

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,4 @@ parameters:
         - */tests/*/fixtures/*
     ignoreErrors:
         - '#Cannot call method getName\(\) on ReflectionType\|null#'
+        - '#Method FormatPHP\\Util\\FormatHelper::loadFormatter\(\) never returns callable\(array\): FormatPHP\\MessageCollection so it can be removed from the return type#'

--- a/src/Util/FormatHelper.php
+++ b/src/Util/FormatHelper.php
@@ -132,7 +132,7 @@ class FormatHelper
     /**
      * @param class-string<ReaderInterface> | class-string<WriterInterface> $type
      *
-     * @return ReaderCallableType | WriterCallableType
+     * @return ReaderType | WriterType
      *
      * @throws ImproperContextException
      * @throws InvalidArgumentException
@@ -147,23 +147,29 @@ class FormatHelper
         $formatter = $this->fileSystemHelper->loadClosureFromScript($format);
 
         if ($type === ReaderInterface::class) {
-            $formatter = $this->validateReaderClosure($formatter);
+            $formatter = $this->validateReaderCallable($formatter);
         } else {
-            $formatter = $this->validateWriterClosure($formatter);
+            $formatter = $this->validateWriterCallable($formatter);
         }
 
         return $formatter;
     }
 
     /**
+     * @return ReaderCallableType
+     *
      * @throws InvalidArgumentException
      *
      * @psalm-suppress UndefinedMethod, PossiblyNullReference
      */
-    private function validateReaderClosure(?Closure $formatter): Closure
+    public function validateReaderCallable(?callable $formatter): callable
     {
         try {
             assert($formatter !== null);
+
+            if (!$formatter instanceof Closure) {
+                $formatter = Closure::fromCallable($formatter);
+            }
 
             $reflected = new ReflectionFunction($formatter);
 
@@ -186,14 +192,20 @@ class FormatHelper
     }
 
     /**
+     * @return WriterCallableType
+     *
      * @throws InvalidArgumentException
      *
      * @psalm-suppress UndefinedMethod, PossiblyNullReference
      */
-    private function validateWriterClosure(?Closure $formatter): Closure
+    public function validateWriterCallable(?callable $formatter): callable
     {
         try {
             assert($formatter !== null);
+
+            if (!$formatter instanceof Closure) {
+                $formatter = Closure::fromCallable($formatter);
+            }
 
             $reflected = new ReflectionFunction($formatter);
 

--- a/tests/CustomMessageLoaderReader.php
+++ b/tests/CustomMessageLoaderReader.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FormatPHP\Test;
+
+use FormatPHP\Format\Reader\FormatPHPReader;
+
+class CustomMessageLoaderReader extends FormatPHPReader
+{
+}

--- a/tests/Util/FormatHelperTest.php
+++ b/tests/Util/FormatHelperTest.php
@@ -150,7 +150,7 @@ class FormatHelperTest extends TestCase
     }
 
     /**
-     * @return array<string, array{writer: string, expectedType: string}>
+     * @return mixed[]
      */
     public function validWriterProvider(): array
     {
@@ -232,6 +232,42 @@ class FormatHelperTest extends TestCase
             ],
             'return type is not array' => [
                 'reader' => __DIR__ . '/fixtures/writer-closure-invalid-05.php',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider validateWriterCallableProvider
+     */
+    public function testValidateWriterCallable(callable $writer): void
+    {
+        $helper = new FormatHelper(new FileSystemHelper());
+
+        $this->assertInstanceOf(Closure::class, $helper->validateWriterCallable($writer));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function validateWriterCallableProvider(): array
+    {
+        $writerInstance = new ChromeWriter();
+
+        return [
+            'formatphp' => [
+                'writer' => new FormatPHPWriter(),
+            ],
+            'callable array' => [
+                'writer' => [$writerInstance, '__invoke'],
+            ],
+            'loaded closure' => [
+                'writer' => require __DIR__ . '/fixtures/writer-closure-01.php',
+            ],
+            'loaded anonymous class' => [
+                'writer' => require __DIR__ . '/fixtures/writer-closure-02.php',
+            ],
+            'closure' => [
+                'writer' => fn (DescriptorCollection $descriptors, WriterOptions $options): array => [],
             ],
         ];
     }

--- a/tests/fixtures/custom-reader.php
+++ b/tests/fixtures/custom-reader.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use FormatPHP\Format\Reader\FormatPHPReader;
+use FormatPHP\MessageCollection;
+
+return fn (array $data): MessageCollection => (new FormatPHPReader())($data);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This is a slight change I decided to make while I was updating the README and noticed this oversight.

This PR allows the message loader to accept the following values for the custom format reader:

* Fully-qualified class name
* An already-instantiated instance object of `FormatPHP\Format\ReaderInterface`
* A callable with the shape `callable(mixed[]): FormatPHP\MessageCollection`
* The path to a script that returns a callable with this shape

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
