### PR TITLE
fix: ensure zero doesn't break parsing & errors don't interrupt hoisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 - 2021-12-17
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Fixed case where errors occurring during flattening would cause `null` to be passed to a method that does not accept `null`
+- Fixed case where "0" character caused a truthy check to fail, since `0 == false`
+
 ## 0.3.0 - 2021-12-16
 
 ### Added

--- a/src/Icu/MessageFormat/Parser.php
+++ b/src/Icu/MessageFormat/Parser.php
@@ -373,21 +373,21 @@ class Parser
 
         while (true) {
             $quoted = $this->tryParseQuote($parentArgType);
-            if ($quoted) {
+            if ($quoted !== null) {
                 $value .= $quoted;
 
                 continue;
             }
 
             $unquoted = $this->tryParseUnquoted($nestingLevel, $parentArgType);
-            if ($unquoted) {
+            if ($unquoted !== null) {
                 $value .= $unquoted;
 
                 continue;
             }
 
             $leftAngle = $this->tryParseLeftAngleBracket();
-            if ($leftAngle) {
+            if ($leftAngle !== null) {
                 $value .= $leftAngle;
 
                 continue;

--- a/tests/Extractor/MessageExtractorTest.php
+++ b/tests/Extractor/MessageExtractorTest.php
@@ -795,7 +795,10 @@ class MessageExtractorTest extends TestCase
         );
 
         ob_start();
-        $extractor->process([__DIR__ . '/Parser/Descriptor/fixtures/*.ph*']);
+        $extractor->process([
+            __DIR__ . '/Parser/Descriptor/fixtures/*.ph*',
+            __DIR__ . '/../fixtures/invalid-message.php',
+        ]);
         $output = ob_get_contents();
         ob_end_clean();
 

--- a/tests/Icu/MessageFormat/ManipulatorTest.php
+++ b/tests/Icu/MessageFormat/ManipulatorTest.php
@@ -64,6 +64,9 @@ class ManipulatorTest extends TestCase
                             other{many cats}}
                     EOD,
             ],
+            'should not mangle numbers in messages' => [
+                'message' => 'All classes are pre-recorded and average 30-40 minutes in total length.',
+            ],
         ];
     }
 }

--- a/tests/Icu/MessageFormat/__snapshots__/ManipulatorTest__testHoistSelectors with data set should not mangle numbers in messages__1.txt
+++ b/tests/Icu/MessageFormat/__snapshots__/ManipulatorTest__testHoistSelectors with data set should not mangle numbers in messages__1.txt
@@ -1,0 +1,1 @@
+All classes are pre-recorded and average 30-40 minutes in total length.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
- Fixed case where "0" character caused a truthy check to fail, since `'0' == false`
- Fixed case where errors occurring during flattening would cause `null` to be passed to a method that doesn't accept `null`

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/
- Confluence: https://skillsharenyc.atlassian.net/wiki/spaces/

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
