### PR TITLE
fix: skip files not having extraction functions to improve speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.3.2 - 2021-12-17
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Check the contents of the file before parsing, to see if any of the formatting functions exist; if not, skip parsing the file
+
 ## 0.3.1 - 2021-12-17
 
 ### Added

--- a/src/Console/Command/ExtractCommand.php
+++ b/src/Console/Command/ExtractCommand.php
@@ -45,6 +45,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_unique;
@@ -275,7 +276,7 @@ class ExtractCommand extends AbstractCommand
 
         /** @var string $inputFunctionNames */
         $inputFunctionNames = $input->getOption('addl-func') ?? '';
-        $additionalFunctionNames = array_map('trim', explode(',', $inputFunctionNames));
+        $additionalFunctionNames = array_filter(array_map('trim', explode(',', $inputFunctionNames)));
         $options->functionNames = array_unique(array_merge($options->functionNames, $additionalFunctionNames));
 
         return $options;

--- a/tests/Extractor/Parser/Descriptor/PhpParserTest.php
+++ b/tests/Extractor/Parser/Descriptor/PhpParserTest.php
@@ -424,6 +424,36 @@ class PhpParserTest extends TestCase
     }
 
     /**
+     * This test covers situations where the formatting functions are not
+     * present in the source code being analyzed, so we should short-circuit
+     * and skip parsing the file.
+     */
+    public function testParse12(): void
+    {
+        $fileSystemHelper = $this->mockery(FileSystemHelper::class);
+
+        $fileSystemHelper
+            ->expects()
+            ->getContents(__DIR__ . '/fixtures/php-parser-12.php')
+            ->andReturn(file_get_contents(__DIR__ . '/fixtures/php-parser-12.php'));
+
+        $fileSystemHelper->shouldNotReceive('writeContents');
+
+        $errors = new ParserErrorCollection();
+
+        $options = new MessageExtractorOptions();
+        $options->functionNames = ['formatMessage', 'translate', 't'];
+
+        $parser = new PhpParser($fileSystemHelper);
+        $descriptors = $parser(__DIR__ . '/fixtures/php-parser-12.php', $options, $errors);
+        $receivedErrors = $this->compileErrors($errors);
+
+        $this->assertContainsOnlyInstancesOf(DescriptorInterface::class, $descriptors);
+        $this->assertCount(0, $descriptors);
+        $this->assertCount(0, $receivedErrors);
+    }
+
+    /**
      * @return string[]
      */
     private function compileErrors(ParserErrorCollection $errors): array

--- a/tests/Extractor/Parser/Descriptor/fixtures/php-parser-12.php
+++ b/tests/Extractor/Parser/Descriptor/fixtures/php-parser-12.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * This PHP script has no FormatPHP functions in it, on purpose.
+ */
+foreach (['foo', 'bar', 'baz'] as $item) {
+    // Do nothing.
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Before fully parsing the code to get the parameters of the string extraction functions, we'll first check the file contents to see if any of the functions exist (using string comparison). If we don't find them in the source code, we can skip parsing the contents.

This saves on some processing time for large code bases.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
