### PR TITLE
fix: normalize filename and try to find a match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.3.3 - 2022-01-13
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Normalize the locale file name before searching for it in `MessageLoader`, to account for differences in case, as well as filesystem case sensitivity (e.g. "en-XB" vs. "en_xb")
+
 ## 0.3.2 - 2021-12-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.3.3 - 2022-01-13
+## 0.3.3 - 2022-01-14
 
 ### Added
 

--- a/src/Extractor/Parser/Descriptor/DescriptorCollectorVisitor.php
+++ b/src/Extractor/Parser/Descriptor/DescriptorCollectorVisitor.php
@@ -49,12 +49,13 @@ use function trim;
  */
 class DescriptorCollectorVisitor extends NodeVisitorAbstract
 {
+    public ParserErrorCollection $errors;
+
     private DescriptorCollection $descriptors;
     private string $filePath;
     private bool $preserveWhitespace;
     private IdInterpolator $idInterpolator;
     private string $idInterpolatorPattern;
-    private ParserErrorCollection $errors;
     private bool $addGeneratedIdsToSourceCode;
 
     /**

--- a/src/Extractor/Parser/Descriptor/PragmaCollectorVisitor.php
+++ b/src/Extractor/Parser/Descriptor/PragmaCollectorVisitor.php
@@ -44,6 +44,8 @@ use function trim;
  */
 class PragmaCollectorVisitor extends NodeVisitorAbstract
 {
+    public ParserErrorCollection $errors;
+
     /**
      * @var array<string, string>
      */
@@ -51,7 +53,6 @@ class PragmaCollectorVisitor extends NodeVisitorAbstract
 
     private string $filePath;
     private ?string $pragmaName;
-    private ParserErrorCollection $errors;
 
     public function __construct(string $filePath, string $pragmaName, ParserErrorCollection $errors)
     {
@@ -132,6 +133,11 @@ class PragmaCollectorVisitor extends NodeVisitorAbstract
 
         preg_match_all('/(([a-z0-9_\-]+):([a-z0-9_\-]+))+/i', $metadata, $matches);
 
+        /**
+         * @psalm-suppress UnnecessaryVarAnnotation
+         * @var int $index
+         * @var string $propertyName
+         */
         foreach ($matches[2] as $index => $propertyName) {
             $compareParsed .= preg_replace('/\s+/', '', strtolower("$propertyName:{$matches[3][$index]}"));
             $this->parsedPragma[$propertyName] = $matches[3][$index];

--- a/src/FormatPHP.php
+++ b/src/FormatPHP.php
@@ -79,7 +79,7 @@ class FormatPHP implements FormatterInterface
         } catch (UnableToGenerateMessageIdException $exception) {
             throw new InvalidArgumentException(
                 'The message descriptor must have an ID or default message',
-                is_int($exception->getCode()) ? $exception->getCode() : 0,
+                is_int($exception->getCode()) ? $exception->getCode() : 0, // @phpstan-ignore-line
                 $exception,
             );
         }

--- a/src/Icu/MessageFormat/Parser/DateTimeSkeletonParser.php
+++ b/src/Icu/MessageFormat/Parser/DateTimeSkeletonParser.php
@@ -118,7 +118,7 @@ class DateTimeSkeletonParser
                         '"e..eee" (weekday) patterns are not supported',
                     );
                 }
-                $options->weekday = ['short', 'long', 'narrow', 'short'][$length - 4];
+                $options->weekday = $this->getWeekdayValue($length - 4);
 
                 break;
             case 'c':
@@ -127,7 +127,7 @@ class DateTimeSkeletonParser
                         '"c..ccc" (weekday) patterns are not supported',
                     );
                 }
-                $options->weekday = ['short', 'long', 'narrow', 'short'][$length - 4];
+                $options->weekday = $this->getWeekdayValue($length - 4);
 
                 break;
             // Period
@@ -201,5 +201,29 @@ class DateTimeSkeletonParser
                     '"Z/O/v/V/X/x" (timeZone) patterns are not supported, use "z" instead',
                 );
         }
+    }
+
+    /**
+     * @psalm-return "long" | "narrow" | "short"
+     */
+    private function getWeekdayValue(int $index): string
+    {
+        switch ($index) {
+            case 1:
+                $value = 'long';
+
+                break;
+            case 2:
+                $value = 'narrow';
+
+                break;
+            case 0:
+            default:
+                $value = 'short';
+
+                break;
+        }
+
+        return $value;
     }
 }

--- a/src/MessageLoader.php
+++ b/src/MessageLoader.php
@@ -35,6 +35,7 @@ use FormatPHP\Util\FormatHelper;
 use function array_filter;
 use function array_unique;
 use function array_values;
+use function file_exists;
 use function implode;
 use function is_callable;
 use function scandir;
@@ -182,6 +183,13 @@ class MessageLoader
 
     private function getFilePathForLocale(string $locale): string
     {
+        $filePath = $this->messagesDirectory . DIRECTORY_SEPARATOR . $locale . self::MESSAGE_FILE_EXTENSION;
+        if (file_exists($filePath)) {
+            return $filePath;
+        }
+
+        // If the file doesn't exist, check for alternate casings and notations.
+        // e.g., en-XB, en_XB, en-xb, en_xb, EN-XB, EN_XB, eN-xB, etc.
         $normalize = fn (string $filename): string => str_replace('_', '-', strtolower($filename));
         $searchFile = $normalize($locale . self::MESSAGE_FILE_EXTENSION);
         $localeFiles = scandir($this->messagesDirectory, SCANDIR_SORT_NONE) ?: [];

--- a/tests/fixtures/locales/en_xb.json
+++ b/tests/fixtures/locales/en_xb.json
@@ -1,0 +1,14 @@
+{
+    "about.inspire": {
+        "defaultMessage": "[!! Ḁṭ Ṡǩíííĺĺśśśḫâŕŕŕè, ẘè èṁṗṗṗŏẘèèèŕ ṁṁṁèṁḃḃḃèŕśśś ṭŏŏŏ ĝèèèṭ íííńśṗṗṗíŕèèèḋ. !!]"
+    },
+    "how.many.pets": {
+        "defaultMessage": "[!! Ļâśśśṭ ṭṭṭíṁèèè Ḭ ćḫèèèćǩèèèḋ,  !!]{gender, select, male{<italicized>[!! ḫè !!]</italicized>[!!  ḫâââḋ !!]} female{<italicized>[!! śḫèèè !!]</italicized>[!!  ḫâââḋ !!]} other{<italicized>[!! ṭḫèèèẏ !!]</italicized>[!!  ḫâââḋ !!]}}[!!   !!]{petCount, plural, =0{<bold>[!! ńŏ !!]</bold>[!!  ṗèèèṭś !!]} =1{<bold>[!! â !!]</bold>[!!  ṗèèèṭ !!]} other{<bold>#</bold>[!!  ṗèèèṭś !!]}}[!! . !!]"
+    },
+    "start.with.tag": {
+        "defaultMessage": "<foo>{argument}</foo>"
+    },
+    "start.with.argument": {
+        "defaultMessage": "{argument}"
+    }
+}


### PR DESCRIPTION
We've been scratching our heads over an issue that appeared to work locally but never in sandbox, staging, or production environments.

Then, I had an ah-ha moment and tried this. First, on my Mac:

```
❯ docker run --rm -it -v $PWD:/app debian:bullseye sh -c 'ls -l /app/composer.json'
-rw-r--r-- 1 root root 23488 Dec 18 00:39 /app/composer.json

❯ docker run --rm -it -v $PWD:/app debian:bullseye sh -c 'ls -l /app/COMPOSER.JSON'
-rw-r--r-- 1 root root 23488 Dec 18 00:39 /app/COMPOSER.JSON
```

Then in a sandbox environment:

```
# ls -l composer.json
-rw-r--r-- 1 root root 23488 Jan 13 00:34 composer.json

# ls -l COMPOSER.JSON
ls: cannot access 'COMPOSER.JSON': No such file or directory
```

Yes, I know the macOS filesystem is case-insensitive, but even when using Linux containers, the directory mounted to the container IS STILL CASE-INSENSITIVE.

Our server environments are all Linux and, therefore, case-sensitive. 💥 

The logic we are using to create the file path for looking up messages is, in short:

```
directory name + locale + ".json"
```

Since we're normalizing the locale name (i.e., `en-xb` and `en_XB` becomes `en-XB`), in a local environment, it works out great because `en-XB.json` and `en-xb.json` are the same files. However, in a server environment, since our locale files are lowercased (i.e., `en-xb.json`), it can't find these files, when running on the servers.

This PR normalizes the file names and searches through the files to find the correct one, comparing the normalized names, rather than concatenating the strings and hoping the files exist.

Fixes SK-36605

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/SK-36605

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in sandbox-3 by loading pages with different locales and confirmed this fixes the problem.

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
