### PR TITLE
feat: allow instantiation of FormatPHP without config or messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Provide functionality for formatting dates and times through `Intl\DateTimeFormat`, as well as `FormatPHP::formatDate()` and `FormatPHP::formatTime()` convenience methods.
 - Add `UnableToFormatStringException` from which other formatting exceptions will descend.
 - Add `UnableToFormatDateTimeException` thrown when we're unable to format a date or time string.
+- Allow instantiation of `FormatPHP` without configuration or message collection instances; FormatPHP will use the system's default locale, in this case.
 
 ### Changed
 

--- a/src/FormatPHP.php
+++ b/src/FormatPHP.php
@@ -27,9 +27,11 @@ use DateTimeInterface as PhpDateTimeInterface;
 use Exception as PhpException;
 use FormatPHP\Intl\DateTimeFormat;
 use FormatPHP\Intl\DateTimeFormatOptions;
+use FormatPHP\Intl\Locale;
 use FormatPHP\Intl\MessageFormat;
 use FormatPHP\Util\MessageCleaner;
 use FormatPHP\Util\MessageRetriever;
+use Locale as PhpLocale;
 
 use function array_merge;
 use function gettype;
@@ -55,12 +57,12 @@ class FormatPHP implements FormatterInterface
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(
-        ConfigInterface $config,
-        MessageCollection $messages
+        ?ConfigInterface $config = null,
+        ?MessageCollection $messages = null
     ) {
-        $this->config = $config;
-        $this->messages = $messages;
-        $this->messageFormat = new MessageFormat($config->getLocale());
+        $this->config = $config ?? new Config(new Locale(PhpLocale::getDefault()));
+        $this->messages = $messages ?? new MessageCollection();
+        $this->messageFormat = new MessageFormat($this->config->getLocale());
     }
 
     /**

--- a/tests/Console/Command/ExtractCommandTest.php
+++ b/tests/Console/Command/ExtractCommandTest.php
@@ -68,7 +68,7 @@ class ExtractCommandTest extends TestCase
             $errorOutput,
         );
         $this->assertStringContainsString(
-            '90     Descriptor argument must have at least one of id, defaultMessage, or',
+            '91     Descriptor argument must have at least one of id, defaultMessage, or',
             $errorOutput,
         );
         $this->assertStringContainsString(

--- a/tests/FormatPHPTest.php
+++ b/tests/FormatPHPTest.php
@@ -12,6 +12,7 @@ use FormatPHP\Intl\DateTimeFormatOptions;
 use FormatPHP\Intl\Locale;
 use FormatPHP\Message;
 use FormatPHP\MessageCollection;
+use Locale as PhpLocale;
 
 use function date;
 
@@ -303,5 +304,47 @@ class FormatPHPTest extends TestCase
         // These should not change after being passed to formatTime().
         $this->assertSame('2-digit', $options->hour);
         $this->assertSame('2-digit', $options->minute);
+    }
+
+    public function testConstructorWithoutConfiguration(): void
+    {
+        $date = 1635204852; // Mon, 25 Oct 2021 23:34:12 +0000
+
+        $systemLocale = PhpLocale::getDefault();
+        $locale = new Locale($systemLocale);
+        $config = new Config($locale);
+        $formatphpForComparison = new FormatPHP($config);
+
+        $formatphpWithoutConfig = new FormatPHP();
+
+        $this->assertSame(
+            $formatphpForComparison->formatDate($date),
+            $formatphpWithoutConfig->formatDate($date),
+        );
+    }
+
+    public function testConstructorWithoutMessages(): void
+    {
+        $date = 1635204852; // Mon, 25 Oct 2021 23:34:12 +0000
+
+        $systemLocale = PhpLocale::getDefault();
+        $locale = new Locale($systemLocale);
+        $config = new Config($locale);
+        $formatphpForComparison = new FormatPHP($config);
+
+        $expectedMessageResponse = $formatphpForComparison->formatMessage(
+            ['defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}'],
+            ['ts' => $date],
+        );
+
+        $formatphpWithoutMessages = new FormatPHP();
+
+        $this->assertSame(
+            $expectedMessageResponse,
+            $formatphpWithoutMessages->formatMessage(
+                ['id' => 'myMessage', 'defaultMessage' => 'Today is {ts, date, ::yyyyMMdd}'],
+                ['ts' => $date],
+            ),
+        );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Allow instantiation of `FormatPHP` without configuration or message collection instances; FormatPHP will use the system's default locale, in this case.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows for easier tinkering in `composer repl`, since it eliminates the need to create locale, config, and message collection objects.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
