### PR TITLE
feat: use defaults for locale in `Intl\Locale` and `Config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `UnableToFormatStringException` from which other formatting exceptions will descend.
 - Add `UnableToFormatDateTimeException` thrown when we're unable to format a date or time string.
 - Allow instantiation of `FormatPHP` without configuration or message collection instances; FormatPHP will use the system's default locale, in this case.
+  - Instantiation of `Intl\Locale` without a locale argument will default to the system default locale.
+  - Instantiation of `Config` without a locale argument will create an `Intl\Locale` using the system default locale.
 
 ### Changed
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace FormatPHP;
 
 use FormatPHP\Extractor\IdInterpolator;
+use FormatPHP\Intl\Locale;
 use FormatPHP\Intl\LocaleInterface;
 
 /**
@@ -43,12 +44,12 @@ class Config implements ConfigInterface
      * @param array<string, callable(string):string> $defaultRichTextElements
      */
     public function __construct(
-        LocaleInterface $locale,
+        ?LocaleInterface $locale = null,
         ?LocaleInterface $defaultLocale = null,
         array $defaultRichTextElements = [],
         string $idInterpolatorPattern = IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN
     ) {
-        $this->locale = $locale;
+        $this->locale = $locale ?? new Locale();
         $this->defaultLocale = $defaultLocale;
         $this->idInterpolatorPattern = $idInterpolatorPattern;
         $this->defaultRichTextElements = $defaultRichTextElements;

--- a/src/FormatPHP.php
+++ b/src/FormatPHP.php
@@ -27,11 +27,9 @@ use DateTimeInterface as PhpDateTimeInterface;
 use Exception as PhpException;
 use FormatPHP\Intl\DateTimeFormat;
 use FormatPHP\Intl\DateTimeFormatOptions;
-use FormatPHP\Intl\Locale;
 use FormatPHP\Intl\MessageFormat;
 use FormatPHP\Util\MessageCleaner;
 use FormatPHP\Util\MessageRetriever;
-use Locale as PhpLocale;
 
 use function array_merge;
 use function gettype;
@@ -60,7 +58,7 @@ class FormatPHP implements FormatterInterface
         ?ConfigInterface $config = null,
         ?MessageCollection $messages = null
     ) {
-        $this->config = $config ?? new Config(new Locale(PhpLocale::getDefault()));
+        $this->config = $config ?? new Config();
         $this->messages = $messages ?? new MessageCollection();
         $this->messageFormat = new MessageFormat($this->config->getLocale());
     }

--- a/src/Intl/Locale.php
+++ b/src/Intl/Locale.php
@@ -46,7 +46,7 @@ use function strtolower;
  */
 class Locale implements LocaleInterface
 {
-    private const UNDEFINED_LOCALE = 'und';
+    public const UNDEFINED_LOCALE = 'und';
 
     /**
      * PHP's canonicalization (through ICU) converts calendar values to those
@@ -121,9 +121,9 @@ class Locale implements LocaleInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(string $locale, ?LocaleOptions $options = null)
+    public function __construct(?string $locale = null, ?LocaleOptions $options = null)
     {
-        if (strtolower($locale) === self::UNDEFINED_LOCALE) {
+        if ($locale === null || strtolower($locale) === self::UNDEFINED_LOCALE) {
             $locale = PhpLocale::getDefault();
         }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -7,6 +7,7 @@ namespace FormatPHP\Test;
 use FormatPHP\Config;
 use FormatPHP\Extractor\IdInterpolator;
 use FormatPHP\Intl\Locale;
+use Locale as PhpLocale;
 
 class ConfigTest extends TestCase
 {
@@ -18,12 +19,24 @@ class ConfigTest extends TestCase
             'em' => fn (string $text): string => '<em class="bar">' . $text . '</em>',
             'strong' => fn (string $text): string => '<strong class="foo">' . $text . '</strong>',
         ];
+        $idInterpolatorPattern = '[md5:contenthash:base64:16]';
 
-        $config = new Config($locale, $defaultLocale, $defaultRichTextElements);
+        $config = new Config($locale, $defaultLocale, $defaultRichTextElements, $idInterpolatorPattern);
 
         $this->assertSame($locale, $config->getLocale());
         $this->assertSame($defaultLocale, $config->getDefaultLocale());
         $this->assertSame($defaultRichTextElements, $config->getDefaultRichTextElements());
+        $this->assertSame($idInterpolatorPattern, $config->getIdInterpolatorPattern());
+    }
+
+    public function testConfigDefaults(): void
+    {
+        $systemLocale = new Locale(PhpLocale::getDefault());
+        $config = new Config();
+
+        $this->assertSame($systemLocale->toString(), $config->getLocale()->toString());
+        $this->assertNull($config->getDefaultLocale());
+        $this->assertSame([], $config->getDefaultRichTextElements());
         $this->assertSame(IdInterpolator::DEFAULT_ID_INTERPOLATION_PATTERN, $config->getIdInterpolatorPattern());
     }
 }

--- a/tests/Intl/LocaleTest.php
+++ b/tests/Intl/LocaleTest.php
@@ -92,9 +92,17 @@ class LocaleTest extends TestCase
     public function testLocaleWithUndefinedLocale(): void
     {
         $defaultLocale = new Locale(PhpLocale::getDefault());
-        $undefinedLocale = new Locale('und');
+        $undefinedLocale = new Locale(Locale::UNDEFINED_LOCALE);
 
         $this->assertSame($defaultLocale->toString(), $undefinedLocale->toString());
+    }
+
+    public function testLocaleWithNoLocale(): void
+    {
+        $defaultLocale = new Locale(PhpLocale::getDefault());
+        $noLocale = new Locale();
+
+        $this->assertSame($defaultLocale->toString(), $noLocale->toString());
     }
 
     public function testBaseNameWithMultipleVariants(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
- Instantiation of `Intl\Locale` without a locale argument will default to the system default locale.
- Instantiation of `Config` without a locale argument will create an `Intl\Locale` using the system default locale.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@xiian suggested this here: https://github.com/Skillshare/formatphp/pull/38#pullrequestreview-859733865

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
