### PR TITLE
fix: do not default to narrowSymbol for currencyDisplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 - 2022-02-01
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Do not default to `narrowSymbol` for `currencyDisplay`.
+
 ## 0.5.0 - 2022-02-01
 
 ### Added

--- a/src/FormatPHP.php
+++ b/src/FormatPHP.php
@@ -152,7 +152,6 @@ class FormatPHP implements FormatterInterface
         $options = $options ?? new NumberFormatOptions();
         $options->style = NumberFormatOptions::STYLE_CURRENCY;
         $options->currency = $currencyCode;
-        $options->currencyDisplay = $options->currencyDisplay ?? NumberFormatOptions::CURRENCY_DISPLAY_NARROW_SYMBOL;
 
         return $this->formatNumber($value, $options);
     }

--- a/tests/FormatPHPTest.php
+++ b/tests/FormatPHPTest.php
@@ -373,17 +373,17 @@ class FormatPHPTest extends TestCase
 
     public function testFormatCurrency(): void
     {
-        $locale = new Locale('en');
+        $locale = new Locale('en-GB');
         $config = new Config($locale);
         $messageCollection = new MessageCollection();
         $formatphp = new FormatPHP($config, $messageCollection);
 
-        $this->assertSame('$1,234.00', $formatphp->formatCurrency(1234, 'USD'));
+        $this->assertSame('US$1,234.00', $formatphp->formatCurrency(1234, 'USD'));
     }
 
     public function testFormatCurrencyWithOptions(): void
     {
-        $locale = new Locale('en');
+        $locale = new Locale('en-US');
         $config = new Config($locale);
         $messageCollection = new MessageCollection();
         $formatphp = new FormatPHP($config, $messageCollection);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Do not default to `narrowSymbol` for `currencyDisplay`.

## Product requirements and context
I noticed this as an issue while updating the monolith with the new version of FormatPHP.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
