### PR TITLE
fix: multiply percentages by 100 internally to match FormatJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,31 @@ When formatting currency, you may use the following properties.
 If `notation` is `compact`, then you may specify the `compactDisplay` property
 with the value `short` or `long`. The default is `short`.
 
+#### Formatting Percentages
+
+According to [ECMA-402, section 15.1.6](https://tc39.es/ecma402/#sec-partitionnumberpattern)
+(specifically step 5.b.), if the style is "percent," then the number formatter
+must multiply the value by 100. This means the formatter expects percent values
+expressed as fractions of 100 (i.e., 0.25 for 25%, 0.055 for 5.5%, etc.).
+
+Since FormatJS also applies this rule to `::percent` number skeletons in
+formatted messages, FormatPHP does, as well.
+
+For example:
+
+```php
+echo $formatphp->formatMessage([
+    'id' => 'discountMessage',
+    'defaultMessage' => 'You get {discount, number, ::percent} off the retail price!',
+], [
+    'discount' => 0.25,
+]); // e.g., "You get 25% off the retail price!"
+
+echo $formatphp->formatNumber(0.25, new Intl\NumberFormatOptions([
+    'style' => 'percent',
+])); // e.g., "25%"
+```
+
 ### Formatting Dates and Times
 
 You may use the methods `formatDate()` and `formatTime()` to format dates and
@@ -341,16 +366,13 @@ echo $formatphp->formatMessage([
     'id' => 'priceMessage',
     'defaultMessage' => <<<'EOD'
         Our price is <boldThis>{price}</boldThis>
-        with <link>{discount} discount</link>
+        with <link>{discount, number, ::percent} discount</link>
         EOD,
 ], [
     'price' => $formatphp->formatCurrency(29.99, 'USD', new Intl\NumberFormatOptions([
         'maximumFractionDigits' => 0,
     ])),
-    'discount' => $formatphp->formatNumber(.025, new Intl\NumberFormatOptions([
-        'style' => 'percent',
-        'minimumFractionDigits' => 1,
-    ])),
+    'discount' => .025,
     'boldThis' => fn ($text) => "<strong>$text</strong>",
     'link' => fn ($text) => "<a href=\"/discounts/1234\">$text</a>",
 ]);

--- a/tests/Intl/MessageFormatTest.php
+++ b/tests/Intl/MessageFormatTest.php
@@ -326,4 +326,56 @@ class MessageFormatTest extends TestCase
             );
         }
     }
+
+    public function testProcessesPercentagesAccordingToEcma402(): void
+    {
+        $message = 'Your discount is {discount, number, ::percent} off the retail value.';
+        $expected = 'Your discount is 25% off the retail value.';
+
+        $locale = new Locale('en-US');
+        $formatter = new MessageFormat($locale);
+
+        $result = $formatter->format($message, ['discount' => 0.25]);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testProcessesPercentagesAccordingToEcma402WithScaleAt100(): void
+    {
+        $message = 'Your discount is {discount, number, ::percent scale/100} off the retail value.';
+        $expected = 'Your discount is 2,500% off the retail value.';
+
+        $locale = new Locale('en-US');
+        $formatter = new MessageFormat($locale);
+
+        $result = $formatter->format($message, ['discount' => 0.25]);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testProcessesPercentagesAccordingToEcma402WithScaleAt1(): void
+    {
+        $message = 'Your discount is {discount, number, ::percent scale/1} off the retail value.';
+        $expected = 'Your discount is 25% off the retail value.';
+
+        $locale = new Locale('en-US');
+        $formatter = new MessageFormat($locale);
+
+        $result = $formatter->format($message, ['discount' => 0.25]);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testProcessesNumberWithoutStyle(): void
+    {
+        $message = 'Your discount is {discount, number} off the retail value.';
+        $expected = 'Your discount is 25 off the retail value.';
+
+        $locale = new Locale('en-US');
+        $formatter = new MessageFormat($locale);
+
+        $result = $formatter->format($message, ['discount' => 25]);
+
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
If the parameter is a percent-style number, then we multiply the value
by 100. This is in keeping with the ECMA-402 draft, which specifies the
`Intl.NumberFormat` rules. When using `Intl.NumberFormat` to format
percentages, the number must first be multiplied by 100 before any
formatting occurs. See section 15.1.6 of ECMA-402, specifically step
5.b.[^1]

ECMA-402, however, doesn't define an API for MessageFormat, so FormatJS
implements this on their own, using `Intl.NumberFormat` to process any
number parameters it encounters.[^2] As a result, all number parameters
in ICU message syntax that specify the `::percent` stem (i.e., "{0,
number, ::percent}") have their values first multiplied by 100 before
formatting them.

This may not be considered a bug in FormatJS, since it is adhering to
the ECMA-402 specification. However, it does not follow the rules for
percentages as programmed in icu4c (the underlying library PHP uses),
so in order to match the expected output of FormatJS, we multiply
percent values by 100 before formatting them.

Oddly enough, PHP's `NumberFormatter` has the same rules, and it uses
the underlying ICU implementation of the number formatter:

    $nf = new NumberFormatter('en-US', NumberFormatter::PERCENT);
    echo $nf->format(25); // Produces "2,500%"

While:

    $mf = new MessageFormatter('en-US', '{0, number, ::percent}');
    echo $mf->format([25]); // Produces "25%"

So, one could argue this is a bug in the ICU implementation of the
percent number skeleton.

[^1]: https://tc39.es/ecma402/#sec-partitionnumberpattern
[^2]: https://formatjs.io/docs/core-concepts/icu-syntax/#number-type


## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/
- Confluence: https://skillsharenyc.atlassian.net/wiki/spaces/

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
