### PR TITLE
fix: implement dayPeriod and ensure hour12 functions properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Additional options include:
   "am", "noon", "n" etc. Values include: `narrow`, `short`, or `long`.
 * `fractionalSecondDigits`: The number of digits used to represent fractions of
   a second (any additional digits are truncated). Values may be: `0`, `1`, `2`,
-  or `3`.
+  or `3`. **This property is not yet implemented.**
 * `hour12`: If `true`, `hourCycle` will be `h12`, if `false`, `hourCycle` will
   be `h23`. This property overrides any value set by `hourCycle`.
 * `hourCycle`: The hour cycle to use. Values include: `h11`, `h12`, `h23`, and

--- a/src/Icu/MessageFormat/Parser/DateTimeSkeletonParser.php
+++ b/src/Icu/MessageFormat/Parser/DateTimeSkeletonParser.php
@@ -144,11 +144,17 @@ class DateTimeSkeletonParser
 
                 break;
             case 'b': // am, pm, noon, midnight
-            case 'B': // flexible day periods
-                throw new Exception\InvalidSkeletonOption(
-                    '"b/B" (period) patterns are not supported, use "a" instead',
-                );
+                if ($length === 5) {
+                    $options->dayPeriod = IntlDateTimeFormatOptions::PERIOD_NARROW;
+                } else {
+                    $options->dayPeriod = IntlDateTimeFormatOptions::PERIOD_SHORT;
+                }
 
+                break;
+            case 'B': // flexible day periods
+                $options->dayPeriod = IntlDateTimeFormatOptions::PERIOD_LONG;
+
+                break;
             // Hour
             case 'h':
                 $options->hourCycle = IntlDateTimeFormatOptions::HOUR_H12;

--- a/src/Intl/NumberFormat.php
+++ b/src/Intl/NumberFormat.php
@@ -191,6 +191,16 @@ class NumberFormat implements NumberFormatInterface
     }
 
     /**
+     * Returns the locale constructed from the date/time format options
+     *
+     * @internal
+     */
+    public function getEvaluatedLocale(): string
+    {
+        return $this->localeName;
+    }
+
+    /**
      * @param int | float $number
      *
      * @throws PhpIntlException

--- a/tests/Icu/MessageFormat/Parser/DateTimeSkeletonParserTest.php
+++ b/tests/Icu/MessageFormat/Parser/DateTimeSkeletonParserTest.php
@@ -66,6 +66,9 @@ class DateTimeSkeletonParserTest extends TestCase
             ['cccccc'],
             ['KK'],
             ['k'],
+            ['hb'],
+            ['hB'],
+            ['hbbbbb'],
         ];
     }
 }

--- a/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 10__1.json
+++ b/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 10__1.json
@@ -1,0 +1,5 @@
+{
+    "dayPeriod": "narrow",
+    "hourCycle": "h12",
+    "hour": "numeric"
+}

--- a/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 8__1.json
+++ b/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 8__1.json
@@ -1,0 +1,5 @@
+{
+    "dayPeriod": "short",
+    "hourCycle": "h12",
+    "hour": "numeric"
+}

--- a/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 9__1.json
+++ b/tests/Icu/MessageFormat/Parser/__snapshots__/DateTimeSkeletonParserTest__testParseDateTimeSkeleton with data set 9__1.json
@@ -1,0 +1,5 @@
+{
+    "dayPeriod": "long",
+    "hourCycle": "h12",
+    "hour": "numeric"
+}

--- a/tests/Intl/NumberFormatTest.php
+++ b/tests/Intl/NumberFormatTest.php
@@ -103,6 +103,24 @@ class NumberFormatTest extends TestCase
         }
     }
 
+    public function testEvaluatedLocaleWithNoOptions(): void
+    {
+        $locale = new Locale('en-US');
+        $formatter = new NumberFormat($locale);
+
+        $this->assertSame('en-US', $formatter->getEvaluatedLocale());
+    }
+
+    public function testEvaluatedLocaleWithOptions(): void
+    {
+        $locale = new Locale('en-US');
+        $formatter = new NumberFormat($locale, new NumberFormatOptions([
+            'numberingSystem' => 'arab',
+        ]));
+
+        $this->assertSame('en-US-u-nu-arab', $formatter->getEvaluatedLocale());
+    }
+
     /**
      * @param int | float $number
      *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
The `dayPeriod` property was an oversight, so this implements it, while fixing a logic error in the `hour12` functionality.

## Product requirements and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: https://skillsharenyc.atlassian.net/browse/
- Confluence: https://skillsharenyc.atlassian.net/wiki/spaces/

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
